### PR TITLE
Travis/Appveyor Configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   ccache: true
   directories:
     - dependencies
+    - build/libs
 
 before_cache:
   - ${TRAVIS_BUILD_DIR}/scripts/cleanup-cmake.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,11 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - llvm-toolchain-trusty-3.9
           packages:
-            - clang-3.7
+            - clang-3.9
       env:
-        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.7' && CXX='ccache clang++-3.7'"
+        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.9' && CXX='ccache clang++-3.9'"
         - CCACHE_CPP2=yes
 
    # ------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,11 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
+            - llvm-toolchain-precise-3.7
           packages:
-            - clang-3.6
+            - clang-3.7
       env:
-        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.6' && CXX='ccache clang++-3.6'"
+        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.7' && CXX='ccache clang++-3.7'"
         - CCACHE_CPP2=yes
 
    # ------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ jobs:
             - llvm-toolchain-trusty-5.0
           packages:
             - libstdc++-6-dev
+            - libiomp5
             - clang-5.0
       env:
         - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-5.0' && CXX='ccache clang++-5.0'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,154 @@
+dist: trusty
+language: cpp
+
+cache:
+  ccache: true
+  directories:
+    - dependencies
+
+before_cache:
+  - ${TRAVIS_BUILD_DIR}/scripts/cleanup-cmake.sh
+
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+
+# Create aliases for some of shared build configuration
+_basic_env:
+- &daily_linux
+  if: type = cron
+  os: linux
+  compiler: gcc
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - g++-6
+        - valgrind
+- &linux_base
+  if: type != cron
+  os: linux
+  compiler: gcc
+- &osx_base
+  if: branch IN (master, develop)
+  os: osx
+  compiler: clang
+
+jobs:
+  # On weekdays, the backlog for waiting OS X builds is huge
+  fast_finish: true
+  allow_failures:
+    - os: osx
+
+  include:
+    # XCode 6.4, OS X 10.10
+    - <<: *osx_base
+      env:
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=64"
+        - HOMEBREW_NO_AUTO_UPDATE=1
+        - CI_BOOST_VERSION=1.58.0
+      osx_image: xcode6.4
+    # XCode 7.3, OS X 10.11
+    - <<: *osx_base
+      env:
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=73"
+        - HOMEBREW_NO_AUTO_UPDATE=1
+      osx_image: xcode7.3
+
+    # Built without errors on my clone from one of the changes made
+    # Possibly local dependencies, or removing Linux-only commands fixed it
+    # XCode 8.3, OS X 10.12
+    #- env: COMPILER=clang++ BUILD_TYPE=Debug
+    #  osx_image: xcode8.3
+
+    - <<: *linux_base
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
+
+    - <<: *linux_base
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-4.9 && CXX=g++-4.9"
+        - CI_BOOST_VERSION=1.61.0
+
+    - <<: *linux_base
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.6' && CXX='ccache clang++-3.6'"
+        - CCACHE_CPP2=yes
+
+   # ------------------------------------------------
+   # Jobs for daily valgrind and code coverage tests
+   # ------------------------------------------------
+    - <<: *daily_linux
+      env:
+        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
+        - RUN_VALGRIND=true
+    - <<: *daily_linux
+      env:
+        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
+        - RUN_COVERAGE=true
+    - <<: *daily_linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="COMPILER=gcc && CC='gcc-5' && CXX='g++-5'"
+    - <<: *daily_linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - libstdc++-6-dev
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-5.0' && CXX='ccache clang++-5.0'"
+        - CCACHE_CPP2=yes
+        - CXX_STANDARD=17
+
+branches:
+  except:
+    - gh-pages
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+  - $CXX --version
+
+install:
+  - source scripts/install-ci-dependencies.sh
+
+script:
+  - mkdir build && cd build
+  - export GRIDDYN_DEPENDENCY_FLAGS="-DBOOST_INSTALL_PATH=${CI_DEPENDENCY_DIR}/boost -DSUNDIALS_DIR=${CI_DEPENDENCY_DIR}/sundials"
+  - export GRIDDYN_OPTION_FLAGS=""
+  - cmake .. ${GRIDDYN_DEPENDENCY_FLAGS} ${GRIDDYN_OPTION_FLAGS}
+  - make -j2
+
+notifications:
+    email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ install:
   - source scripts/install-ci-dependencies.sh
 
 script:
-  - mkdir build && cd build
+  - mkdir -p build && cd build
   - export GRIDDYN_DEPENDENCY_FLAGS="-DBOOST_INSTALL_PATH=${CI_DEPENDENCY_DIR}/boost -DSUNDIALS_DIR=${CI_DEPENDENCY_DIR}/sundials"
   - export GRIDDYN_OPTION_FLAGS=""
   - cmake .. ${GRIDDYN_DEPENDENCY_FLAGS} ${GRIDDYN_OPTION_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,12 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.9
+            - llvm-toolchain-trusty-5.0
           packages:
-            - clang-3.9
+            - libstdc++-6-dev
+            - clang-5.0
       env:
-        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.9' && CXX='ccache clang++-3.9'"
+        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-5.0' && CXX='ccache clang++-5.0'"
         - CCACHE_CPP2=yes
 
    # ------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![image](docs/images/GridDyn_FullColor.png "GridDyn")
 ============
 [![Build Status](https://travis-ci.org/LLNL/GridDyn.svg?branch=master)](https://travis-ci.org/LLNL/GridDyn)
-[![Build status](https://ci.appveyor.com/api/projects/status/<update_url>/branch/develop?svg=true)](https://ci.appveyor.com/project/griddyn/griddyn/branch/develop)
+[![Build status](https://ci.appveyor.com/api/projects/status/e3rygs874w04a25n?svg=true)](https://ci.appveyor.com/project/griddyn/griddyn)
 [![Gitter chat](https://badges.gitter.im/LLNL/GridDyn.png)](https://gitter.im/LLNL/GridDyn)
 
 GridDyn is a power system simulator developed at Lawrence Livermore National Laboratory. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![image](docs/images/GridDyn_FullColor.png "GridDyn")
 ============
+[![Build Status](https://travis-ci.org/LLNL/GridDyn.svg?branch=master)](https://travis-ci.org/LLNL/GridDyn)
+[![Build status](https://ci.appveyor.com/api/projects/status/<update_url>/branch/develop?svg=true)](https://ci.appveyor.com/project/griddyn/griddyn/branch/develop)
+[![Gitter chat](https://badges.gitter.im/LLNL/GridDyn.png)](https://gitter.im/LLNL/GridDyn)
 
 GridDyn is a power system simulator developed at Lawrence Livermore National Laboratory. 
 The name is a concatenation of Grid Dynamics, and as such usually pronounced as "Grid Dine". 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,6 @@ configuration:
 
 cache:
   - build\libs
-#  - foldername -> dependencyfile #caches foldername, but will ignore/update cache if dependencyfile changes
-#  surround entire line with single-quotes to make env variable substitution work
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ platform:
 configuration:
   - Release
 
+#cache:
+#  - foldername -> dependencyfile #caches foldername, but will ignore/update cache if dependencyfile changes
+#  surround entire line with single-quotes to make env variable substitution work
+
 install:
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 shallow_clone: true
 
-version: 1.0.0.alpha2.{build}
+version: 0.0.0.alpha2.{build}
 
 image: Visual Studio 2015
 
@@ -13,14 +13,13 @@ configuration:
 install:
 
 before_build:
-  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --yes --limit-output #> $null
   - mkdir build
   - cd build
-  - cmake .. -G "Visual Studio 14 2015 Win64" -DAUTOBUILD_ZMQ=ON -DBUILD_RELEASE_ONLY=ON -DBUILD_C_SHARED_LIB=ON -DBUILD_HELICS_EXAMPLES=ON -DQUICK_TESTS_ONLY=ON
+  - cmake .. -G "Visual Studio 14 2015 Win64" -DBOOST_INSTALL_PATH=C:/libraries/boost_1_63_0
   - cd ..
 
 build:
-  project: build/HELICS.sln
+  project: build/GridDyn.sln
   parallel: true
   verbosity: minimal
 
@@ -30,15 +29,5 @@ test_script:
   - cd build
   # For controlling which tests get run:
   # ctest -I <start>,<end>,<stride>,<list of test numbers>
-  # 1 = common_tests
-  # 2 = core tests
-  # 3 = application api tests
-  # 4 = c interface tests
-  # 5 = app tests
-  # 6 = travis_tests
-  - ctest -C Release --verbose --timeout 120 -I 0,0,0,1
-  - ctest -C Release --verbose --timeout 90 -I 0,0,0,2
-  - ctest -C Release --verbose --timeout 240 -I 0,0,0,3
-  - ctest -C Release --verbose --timeout 90 -I 0,0,0,5
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,16 @@ platform:
 configuration:
   - Release
 
-#cache:
+cache:
+  - build\libs
 #  - foldername -> dependencyfile #caches foldername, but will ignore/update cache if dependencyfile changes
 #  surround entire line with single-quotes to make env variable substitution work
 
 install:
 
 before_build:
-  - mkdir build
+  # Make the build directory if it doesn't already exist
+  - IF NOT EXIST build mkdir build
   - cd build
   - cmake .. -G "Visual Studio 14 2015 Win64" -DBOOST_INSTALL_PATH=C:/libraries/boost_1_63_0
   - cd ..

--- a/config/cmake/buildSundials.cmake
+++ b/config/cmake/buildSundials.cmake
@@ -29,7 +29,9 @@ function (build_sundials)
     cmake_minimum_required(VERSION 3.5)
     include(ExternalProject)
 ExternalProject_Add(sundials
-    URL https://computation.llnl.gov/projects/sundials/download/sundials-3.1.0.tar.gz
+    SOURCE_DIR ${PROJECT_BINARY_DIR}/Download/sundials
+    GIT_REPOSITORY  https://github.com/llnl/sundials.git
+    GIT_TAG v3.1.0
     UPDATE_COMMAND " " 
     BINARY_DIR ${PROJECT_BINARY_DIR}/ThirdParty/sundials
      
@@ -115,7 +117,9 @@ message(STATUS "BUILD SUNDIALS with MINGW")
     cmake_minimum_required(VERSION 3.5)
     include(ExternalProject)
 ExternalProject_Add(sundials
-    URL https://computation.llnl.gov/projects/sundials/download/sundials-3.1.0.tar.gz
+    SOURCE_DIR ${PROJECT_BINARY_DIR}/Download/sundials
+    GIT_REPOSITORY  https://github.com/llnl/sundials.git
+    GIT_TAG v3.1.0
     UPDATE_COMMAND " " 
     BINARY_DIR ${PROJECT_BINARY_DIR}/ThirdParty/sundials
      

--- a/scripts/cleanup-cmake.sh
+++ b/scripts/cleanup-cmake.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
+
+# Get rid of unneeded files that just take up extra space
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    rm -rf ${cmake_install_path}/doc
+    rm -rf ${cmake_install_path}/man
+    rm -f ${cmake_install_path}/bin/ccmake
+    rm -f ${cmake_install_path}/bin/cmake-gui
+elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    rm -rf ${cmake_install_path}/CMake.app/Contents/Frameworks
+    rm -rf ${cmake_install_path}/CMake.app/Contents/MacOS
+    rm -rf ${cmake_install_path}/CMake.app/Contents/Resources
+    rm -rf ${cmake_install_path}/CMake.app/Contents/doc
+    rm -rf ${cmake_install_path}/CMake.app/Contents/man
+    rm -f ${cmake_install_path}/CMake.app/Contents/bin/ccmake
+    rm -f ${cmake_install_path}/CMake.app/Contents/bin/cmake-gui
+fi
+

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -28,7 +28,7 @@ if [[ -z "$CI_BOOST_VERSION" ]]; then
 fi
 boost_install_path=${CI_DEPENDENCY_DIR}/boost
 
-cmake_version=3.4.3
+cmake_version=3.5.2
 cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
 
 sundials_version=3.1.0

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -71,13 +71,7 @@ if [[ ! -d "${boost_install_path}" ]]; then
 fi
 
 if [[ "$os_name" == "Linux" ]]; then
-    export LD_LIBRARY_PATH=${zmq_install_path}/lib:${boost_install_path}/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=${boost_install_path}/lib:$LD_LIBRARY_PATH
 elif [[ "$os_name" == "Darwin" ]]; then
-    export DYLD_FALLBACK_LIBRARY_PATH=${zmq_install_path}/lib:${boost_install_path}/lib:$DYLD_FALLBACK_LIBRARY_PATH
-fi
-
-if [[ "$os_name" == "Linux" ]]; then
-    export LD_LIBRARY_PATH=${PWD}/build/src/helics/shared_api_library/:$LD_LIBRARY_PATH
-elif [[ "$os_name" == "Darwin" ]]; then
-    export DYLD_FALLBACK_LIBRARY_PATH=${PWD}/build/src/helics/shared_api_library/:$DYLD_FALLBACK_LIBRARY_PATH
+    export DYLD_FALLBACK_LIBRARY_PATH=${boost_install_path}/lib:$DYLD_FALLBACK_LIBRARY_PATH
 fi

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -28,7 +28,7 @@ if [[ -z "$CI_BOOST_VERSION" ]]; then
 fi
 boost_install_path=${CI_DEPENDENCY_DIR}/boost
 
-cmake_version=3.5.2
+cmake_version=3.11.0
 cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
 
 sundials_version=3.1.0

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -24,25 +24,18 @@ fi
 
 boost_version=$CI_BOOST_VERSION
 if [[ -z "$CI_BOOST_VERSION" ]]; then
-    boost_version=1.66.0
+    boost_version=1.63.0
 fi
 boost_install_path=${CI_DEPENDENCY_DIR}/boost
 
-cmake_version=3.11.0
+cmake_version=3.5.2
 cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
-
-sundials_version=3.1.0
-sundials_install_path=${CI_DEPENDENCY_DIR}/sundials
 
 # Wipe out cached dependencies if commit message has '[update_cache]'
 if [[ $commit_msg == *'[update_cache]'* ]]; then
     individual="false"
     if [[ $commit_msg == *'boost'* ]]; then
         rm -rf ${boost_install_path};
-        individual="true"
-    fi
-    if [[ $commit_msg == *'sundials'* ]]; then
-        rm -rf ${sundials_install_path};
         individual="true"
     fi
 
@@ -75,12 +68,6 @@ if [[ ! -d "${boost_install_path}" ]]; then
     echo "*** build boost"
     travis_wait ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}
     echo "*** built boost successfully"
-fi
-
-# Install Sundials
-if [[ ! -d "${sundials_install_path}" ]]; then
-    #scripts/install-dependency.sh sundials ${sundials_version} ${sundials_install_path}
-    echo "*** built sundials successfully"
 fi
 
 if [[ "$os_name" == "Linux" ]]; then

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -24,7 +24,7 @@ fi
 
 boost_version=$CI_BOOST_VERSION
 if [[ -z "$CI_BOOST_VERSION" ]]; then
-    boost_version=1.65.0
+    boost_version=1.66.0
 fi
 boost_install_path=${CI_DEPENDENCY_DIR}/boost
 

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -79,7 +79,7 @@ fi
 
 # Install Sundials
 if [[ ! -d "${sundials_install_path}" ]]; then
-    scripts/install-dependency.sh sundials ${sundials_version} ${sundials_install_path}
+    #scripts/install-dependency.sh sundials ${sundials_version} ${sundials_install_path}
     echo "*** built sundials successfully"
 fi
 

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Set variables based on build environment
+if [[ "$TRAVIS" == "true" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre
+    fi
+
+    export CI_DEPENDENCY_DIR=${TRAVIS_BUILD_DIR}/dependencies
+
+    # Convert commit message to lower case
+    commit_msg=$(tr '[:upper:]' '[:lower:]' <<< ${TRAVIS_COMMIT_MESSAGE})
+
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        os_name="Linux"
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        os_name="Darwin"
+    fi
+else
+    export CI_DEPENDENCY_DIR=$1
+    commit_msg=""
+    os_name="$(uname -s)"
+fi
+
+boost_version=$CI_BOOST_VERSION
+if [[ -z "$CI_BOOST_VERSION" ]]; then
+    boost_version=1.65.0
+fi
+boost_install_path=${CI_DEPENDENCY_DIR}/boost
+
+cmake_version=3.4.3
+cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
+
+sundials_version=3.1.0
+sundials_install_path=${CI_DEPENDENCY_DIR}/sundials
+
+# Wipe out cached dependencies if commit message has '[update_cache]'
+if [[ $commit_msg == *'[update_cache]'* ]]; then
+    individual="false"
+    if [[ $commit_msg == *'boost'* ]]; then
+        rm -rf ${boost_install_path};
+        individual="true"
+    fi
+    if [[ $commit_msg == *'sundials'* ]]; then
+        rm -rf ${sundials_install_path};
+        individual="true"
+    fi
+
+    # If no dependency named in commit message, update entire cache
+    if [[ "$individual" != 'true' ]]; then
+        rm -rf ${CI_DEPENDENCY_DIR};
+    fi
+fi
+
+if [[ ! -d "${CI_DEPENDENCY_DIR}" ]]; then
+    mkdir -p ${CI_DEPENDENCY_DIR};
+fi
+
+# Install CMake
+if [[ ! -d "${cmake_install_path}" ]]; then
+    ./scripts/install-dependency.sh cmake ${cmake_version} ${cmake_install_path}
+fi
+
+# Set path to CMake executable depending on OS
+if [[ "$os_name" == "Linux" ]]; then
+    export PATH="${cmake_install_path}/bin:${PATH}"
+    echo "*** cmake installed ($PATH)"
+elif [[ "$os_name" == "Darwin" ]]; then
+    export PATH="${cmake_install_path}/CMake.app/Contents/bin:${PATH}"
+    echo "*** cmake installed ($PATH)"
+fi
+
+# Install Boost
+if [[ ! -d "${boost_install_path}" ]]; then
+    echo "*** build boost"
+    travis_wait ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}
+    echo "*** built boost successfully"
+fi
+
+# Install Sundials
+if [[ ! -d "${sundials_install_path}" ]]; then
+    scripts/install-dependency.sh sundials ${sundials_version} ${sundials_install_path}
+    echo "*** built sundials successfully"
+fi
+
+if [[ "$os_name" == "Linux" ]]; then
+    export LD_LIBRARY_PATH=${zmq_install_path}/lib:${boost_install_path}/lib:$LD_LIBRARY_PATH
+elif [[ "$os_name" == "Darwin" ]]; then
+    export DYLD_FALLBACK_LIBRARY_PATH=${zmq_install_path}/lib:${boost_install_path}/lib:$DYLD_FALLBACK_LIBRARY_PATH
+fi
+
+if [[ "$os_name" == "Linux" ]]; then
+    export LD_LIBRARY_PATH=${PWD}/build/src/helics/shared_api_library/:$LD_LIBRARY_PATH
+elif [[ "$os_name" == "Darwin" ]]; then
+    export DYLD_FALLBACK_LIBRARY_PATH=${PWD}/build/src/helics/shared_api_library/:$DYLD_FALLBACK_LIBRARY_PATH
+fi

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+if [[ $DEBUG_INSTALL_DEPENDENCY ]]; then
+    set -x
+fi
+
+# Compares two semantic version numbers (major.minor.revision)
+check_minimum_version () {
+    local -a ver
+    IFS='. ' read -r -a ver <<< $1
+
+    local -a ver_min
+    IFS='. ' read -r -a ver_min <<< $2
+
+    if [[ ${ver[0]} -lt ${ver_min[0]} ]] || [[ ${ver[0]} -eq ${ver_min[0]} && ${ver[1]} -lt ${ver_min[1]} ]] || [[ ${ver[0]} -eq ${ver_min[0]} && ${ver[1]} -eq ${ver_min[1]} && ${ver[2]} -lt ${ver_min[2]} ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+install_sundials () {
+    local sundials_version=$1
+    local sundials_version_str=sundials-${sundials_version}
+    local install_path=$2
+    if [[ $KLU_INLUDE_DIR ]]; then
+        if [[ $KLU_LIBRARY_DIR ]]; then
+            local klu_options="-DKLU_ENABLE=ON -DKLU_INCLUDE_DIR=${KLU_INCLUDE_DIR} -DKLU_LIBRARY_DIR=${KLU_LIBRARY_DIR}"
+        fi
+    fi
+    if [[ $SUITESPARSECONFIG_LIBRARY ]]; then
+        local suitesparse_option="-DSUITESPARSECONFIG_LIBRARY=${SUITESPARSECONFIG_LIBRARY}"
+    fi
+    wget --no-check-certificate -O ${sundials_version_str}.tar.gz https://computation.llnl.gov/projects/sundials/download/${sundials_version_str}.tar.gz;
+    tar xzf ${sundials_version_str}.tar.gz;
+    (
+        cd ${sundials_version_str}/;
+        mkdir -p build && cd build;
+        cmake .. ${klu_options} ${suitesparse_option} -DBUILD_CVODES=OFF -DBUILD_IDAS=OFF -DBUILD_SHARED_LIBS=OFF -DEXAMPLES_INSTALL=OFF -DEXAMPLES_ENABLE_C=OFF -DEXAMPLES_ENABLE_F77=OFF -DEXAMPLES_ENABLED=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
+        make;
+        make install;
+    )
+}
+
+install_swig () {
+    #Download and install SWIG
+    local swig_version=$1
+    local swig_version_str=swig-${swig_version}
+    local install_path=$2
+    curl -s -J -k -L -O https://sourceforge.net/projects/swig/files/swig/${swig_version_str}/${swig_version_str}.tar.gz/download && tar -zxf ${swig_version_str}.tar.gz
+    (
+        cd ${swig_version_str};
+        ./configure --prefix ${install_path};
+        make;
+        make install;
+    )
+    rm ${swig_version_str}.tar.gz
+}
+
+install_zmq () {
+    # Clone the zeromq repo and build it
+    local zmq_version=$1
+    local install_path=$2
+    if [[ "${zmq_version}" == "HEAD" ]]; then
+        git clone git://github.com/zeromq/libzmq.git;
+    else
+        git clone --branch v${zmq_version} git://github.com/zeromq/libzmq.git;
+    fi
+    (
+        cd libzmq;
+        ./autogen.sh;
+        mkdir -p build && cd build;
+        cmake .. -DENABLE_CURVE=OFF -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
+        make;
+        make install;
+    )
+}
+
+install_mpich () {
+    # MPICH version number splitting
+    local -a ver
+    IFS='. ' read -r -a ver <<< $1
+
+    # Download and install MPICH (only works with v3+, version number scheme is different for v2)
+    local mpich_version=$1
+    local mpich_version_str=mpich-${mpich_version}
+    local install_path=$2
+    wget --no-check-certificate -O ${mpich_version_str}.tar.gz http://www.mpich.org/static/downloads/${mpich_version}/${mpich_version_str}.tar.gz;
+    tar xzf ${mpich_version_str}.tar.gz ;
+    (
+        cd ${mpich_version_str}/;
+        ./configure --prefix=${install_path} \
+            --disable-dependency-tracking \
+            --enable-fast=yes \
+            --enable-g=none \
+            --enable-timing=none \
+            --enable-shared \
+            --disable-static \
+            --disable-java \
+            --disable-fortran \
+            --enable-threads=serialized ;
+        make;
+        make install;
+    )
+    rm ${mpich_version_str}.tar.gz
+}
+
+
+install_openmpi () {
+    # Open MPI version number splitting
+    local -a ver
+    IFS='. ' read -r -a ver <<< $1
+
+    # Download and install Open MPI
+    local openmpi_version=$1
+    local openmpi_short_ver=v${ver[0]}.${ver[1]}
+    local openmpi_version_str=openmpi-${openmpi_version}
+    local install_path=$2
+    wget --no-check-certificate -O ${openmpi_version_str}.tar.gz https://www.open-mpi.org/software/ompi/${openmpi_short_ver}/downloads/${openmpi_version_str}.tar.gz;
+    tar xzf ${openmpi_version_str}.tar.gz ;
+    (
+        cd ${openmpi_version_str}/;
+        ./configure --prefix=${install_path} \
+            --disable-dependency-tracking \
+            --enable-coverage=no \
+            --enable-shared=yes \
+            --enable-static=no \
+            --enable-java=no \
+            --enable-mpi-fortran=no ;
+        make;
+        make install;
+    )
+    rm ${openmpi_version_str}.tar.gz
+}
+
+install_boost () {
+    # Split argument 1 into 'ver' array, using '.' as delimiter
+    local -a ver
+    IFS='. ' read -r -a ver <<< $1
+
+    # Download and install Boost
+    local boost_version=$1
+    local boost_version_str=boost_${ver[0]}_${ver[1]}_${ver[2]}
+    local install_path=$2
+    local boost_toolset=$3
+    wget --no-check-certificate -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf ${boost_version_str}.tar.gz
+    (
+        cd ${boost_version_str}/;
+        ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,chrono,timer,test;
+        ./b2 -j2 \
+            link=shared \
+            threading=multi \
+            variant=release \
+            toolset=${boost_toolset} \
+            cxxflags=${BOOST_CXX_FLAGS} > /dev/null;
+        ./b2 install --prefix=${install_path} > /dev/null;
+    )
+    rm ${boost_version_str}.tar.gz
+}
+
+install_cmake () {
+    # Split CMake version
+    local -a ver
+    IFS='. ' read -r -a ver <<< $1
+
+    # Download cmake
+    # uname for Linux/Darwin
+    local os_name="$(uname -s)"
+    local cmake_version=$1
+    local cmake_version_str=cmake-${cmake_version}-${os_name}-x86_64
+    local install_path=$2
+    wget --no-check-certificate -O ${cmake_version_str}.tar.gz http://cmake.org/files/v${ver[0]}.${ver[1]}/${cmake_version_str}.tar.gz;
+    tar -xzf ${cmake_version_str}.tar.gz ;
+
+    # Move cmake to "install" location
+    mv ${cmake_version_str} ${install_path};
+    rm ${cmake_version_str}.tar.gz
+}
+
+
+install_version=$2
+install_path=$3
+
+compiler_toolset=$4
+if [[ -z $compiler_toolset ]]; then
+    case $COMPILER in
+        gcc*)
+            compiler_toolset=gcc
+            ;;
+        clang*)
+            compiler_toolset=clang
+            ;;
+        intel*)
+            compiler_toolset=intel
+            ;;
+        *)
+            compiler_toolset=gcc
+    esac
+fi
+
+if [[ "$CXX_STANDARD" == 17 ]]; then
+    echo "Install dependency with C++17 flag requested"
+    BOOST_CXX_FLAGS="-std=c++17"
+elif [[ "$CXX_STANDARD" == 14 ]]; then
+    echo "Install dependency with C++14 flag requested"
+    BOOST_CXX_FLAGS="-std=c++14"
+fi
+
+
+# If FORCE_TOOLSET is set, create symlinks and add directory to path
+# May be needed to force boost to build with the right compiler version
+if [[ "$FORCE_TOOLSET" ]]; then
+    case ${compiler_toolset} in
+        gcc*)
+            ln -s $(which ${CC}) gcc
+            ln -s $(which ${CXX}) g++
+            ;;
+        clang*)
+            ln -s $(which ${CC}) clang
+            ln -s $(which ${CXX}) clang++
+            ;;
+        intel*)
+            ln -s $(which ${CXX}) icc
+            ;;
+        *)
+            echo "Unrecognized compiler toolset"
+    esac
+    PATH=$(pwd):$PATH
+fi
+
+case "$1" in
+    boost)
+        install_boost ${install_version} ${install_path} ${compiler_toolset}
+        ;;
+    cmake)
+        install_cmake ${install_version} ${install_path}
+        ;;
+    mpich)
+        install_mpich ${install_version} ${install_path}
+        ;;
+    openmpi)
+        install_openmpi ${install_version} ${install_path}
+        ;;
+    sundials)
+        install_sundials ${install_version} ${install_path}
+        ;;
+    swig)
+        install_swig ${install_version} ${install_path}
+        ;;
+    zmq)
+        if [[ -z $install_path ]]; then
+            install_version="HEAD"
+            install_path=$2
+        fi
+        install_zmq ${install_version} ${install_path}
+        ;;
+    *)
+        echo "Usage:"
+        echo "$0 (cmake|mpich|openmpi|swig) version install_path"
+        echo "$0 boost version install_path [toolset=gcc]"
+        echo "$0 zmq [version=HEAD] install_path"
+esac
+
+if [[ $DEBUG_INSTALL_DEPENDENCY ]]; then
+    set +x
+fi

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -19,29 +19,6 @@ check_minimum_version () {
     fi
 }
 
-install_sundials () {
-    local sundials_version=$1
-    local sundials_version_str=sundials-${sundials_version}
-    local install_path=$2
-    if [[ $KLU_INLUDE_DIR ]]; then
-        if [[ $KLU_LIBRARY_DIR ]]; then
-            local klu_options="-DKLU_ENABLE=ON -DKLU_INCLUDE_DIR=${KLU_INCLUDE_DIR} -DKLU_LIBRARY_DIR=${KLU_LIBRARY_DIR}"
-        fi
-    fi
-    if [[ $SUITESPARSECONFIG_LIBRARY ]]; then
-        local suitesparse_option="-DSUITESPARSECONFIG_LIBRARY=${SUITESPARSECONFIG_LIBRARY}"
-    fi
-    wget --no-check-certificate -O ${sundials_version_str}.tar.gz https://computation.llnl.gov/projects/sundials/download/${sundials_version_str}.tar.gz;
-    tar xzf ${sundials_version_str}.tar.gz;
-    (
-        cd ${sundials_version_str}/;
-        mkdir -p build && cd build;
-        cmake .. ${klu_options} ${suitesparse_option} -DOPENMP_ENABLE=ON -DBUILD_CVODES=OFF -DBUILD_IDAS=OFF -DBUILD_SHARED_LIBS=OFF -DEXAMPLES_INSTALL=OFF -DEXAMPLES_ENABLE_C=OFF -DEXAMPLES_ENABLE_F77=OFF -DEXAMPLES_ENABLED=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
-        make;
-        make install;
-    )
-}
-
 install_swig () {
     #Download and install SWIG
     local swig_version=$1
@@ -240,9 +217,6 @@ case "$1" in
         ;;
     openmpi)
         install_openmpi ${install_version} ${install_path}
-        ;;
-    sundials)
-        install_sundials ${install_version} ${install_path}
         ;;
     swig)
         install_swig ${install_version} ${install_path}

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -36,7 +36,7 @@ install_sundials () {
     (
         cd ${sundials_version_str}/;
         mkdir -p build && cd build;
-        cmake .. ${klu_options} ${suitesparse_option} -DBUILD_CVODES=OFF -DBUILD_IDAS=OFF -DBUILD_SHARED_LIBS=OFF -DEXAMPLES_INSTALL=OFF -DEXAMPLES_ENABLE_C=OFF -DEXAMPLES_ENABLE_F77=OFF -DEXAMPLES_ENABLED=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
+        cmake .. ${klu_options} ${suitesparse_option} -DOPENMP_ENABLE=ON -DBUILD_CVODES=OFF -DBUILD_IDAS=OFF -DBUILD_SHARED_LIBS=OFF -DEXAMPLES_INSTALL=OFF -DEXAMPLES_ENABLE_C=OFF -DEXAMPLES_ENABLE_F77=OFF -DEXAMPLES_ENABLED=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
         make;
         make install;
     )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -39,7 +39,7 @@ set(coreObject_sources
 	)
 	
 	add_library(coreObjects STATIC ${coreObject_headers} ${coreObject_sources})
-	target_include_directories(coreObjects PUBLIC ${Boost_INCLUDE_DIRS})
+	target_include_directories(coreObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 	set_target_properties (coreObjects PROPERTIES FOLDER libraries)
 	target_link_libraries(coreObjects PUBLIC utilities)
 	INSTALL(TARGETS coreObjects 

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -107,7 +107,7 @@ include(${PROJECT_BINARY_DIR}/libs/cmake/minizip-targets.cmake)
 
 
 target_link_libraries(utilities PUBLIC minizip::minizip zlib::zlib griddyn_base)
-target_include_directories(utilities PUBLIC ${Boost_INCLUDE_DIR})
+target_include_directories(utilities SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(utilities PUBLIC ${Boost_LIBRARIES_core})
 set_target_properties (utilities PROPERTIES FOLDER libraries)
 

--- a/test/testSharedLibrary/CMakeLists.txt
+++ b/test/testSharedLibrary/CMakeLists.txt
@@ -20,7 +20,7 @@ basic_tests.cpp
 
 add_executable(shared_library_tests ${shared_library_test_sources} ${shared_library_test_headers})
 
-target_include_directories(shared_library_tests PUBLIC ${Boost_INCLUDE_DIR})
+target_include_directories(shared_library_tests SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
 target_include_directories(shared_library_tests PUBLIC ${PROJECT_SOURCE_DIR}/src/griddyn_shared)
 
 


### PR DESCRIPTION
Here's the current status of the various builds. There are some problems I'm not sure about that are making a few build configurations not compile (maybe the oldest macOS configuration doesn't need to be supported) and the others marked as failed -- the gcc and more recent macOS builds compile fine, but an error from cmake about a prefixed path for Boost marks the build as failed. I don't know why it has problems with the Boost path, the same paths seem to be fine when building Helics.

* Appveyor build with VS2015 using Boost 1.63.0, caches the build\libs folder. Caching avoids recompiling suitesparse/sundials (longest dependencies to build) and cuts the build time from 18 minutes to 8, but other third party dependencies are also cached -- may be better to have separate cache entries for each dependency?
* Travis CI builds using gcc 4.9 (boost 1.61) and 6 (boost 1.65) work on Linux, clang build on Linux is having trouble with some command line option that ccache doesn't recognize -- maybe something in the CMake config? Tried various versions of clang 3.x and 5.
* Travis CI build for macOS using xcode 7 (boost 1.65) work; build with older macOS and xcode 6 (boost 1.58) doesn't recognize some library functions (ex: find_first_of)
* Travis builds cache the build/libs folder (time saved compared to building suitesparse/sundials each time is very small compared to on Windows)
* buildSundials.cmake fetches v3.1.0 from the LLNL/Sundials github repository instead of using the llnl website -- this should make autobuilding work on LC
* Changed some target_include_directory statements for Boost to include Boost as a SYSTEM dependency to silence the large number of warnings about undefined Boost macros that flooded the build logs
* Added travis and appveyor build status badges and the gitter badge to the readme.