### PR TITLE
Fix most clang-tidy issues with formatInterpreters and core

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,9 @@
 ---
-Checks:         '*,-llvm-include-order,-llvm-header-guard,-readability-redundant-declaration,-misc-unused-parameters,-modernize-use-override,-cppcoreguidelines-pro-type-vararg,-google-default-arguments,-google-runtime-references,-google-readability-todo,-google-readability-namespace-comments,-clang-analyzer-alpha.core.CastToStruct,-clang-diagnostic-pragma-once-outside-header,-google-build-using-namespace,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cert-err58-cpp,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-reinterpret-cast,-misc-misplaced-widening-cast,-clang-analyzer-alpha.deadcode.UnreachableCode'
+Checks:         '*,-fuchsia-default-arguments,-llvm-include-order,-llvm-header-guard,-readability-redundant-declaration,-misc-unused-parameters,-modernize-use-override,-cppcoreguidelines-pro-type-vararg,-google-default-arguments,-google-runtime-references,-google-readability-todo,-google-readability-namespace-comments,-clang-analyzer-alpha.core.CastToStruct,-clang-diagnostic-pragma-once-outside-header,-google-build-using-namespace,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cert-err58-cpp,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-reinterpret-cast,-misc-misplaced-widening-cast,-clang-analyzer-alpha.deadcode.UnreachableCode'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-CheckOptions:    
+CheckOptions:
   - key:             cert-dcl59-cpp.HeaderFileExtensions
     value:           h,hh,hpp,hxx
   - key:             cert-err61-cpp.CheckThrowTemporaries

--- a/src/core/coreObject.cpp
+++ b/src/core/coreObject.cpp
@@ -69,10 +69,10 @@ coreObject *coreObject::clone (coreObject *obj) const
 
 void coreObject::updateName ()
 {
-	if (name.empty())
-	{
-		return;
-	}
+    if (name.empty())
+    {
+        return;
+    }
     switch (name.back ())
     {
     case '$':
@@ -166,10 +166,10 @@ void coreObject::set (const std::string &param, const std::string &val)
     {
         setDescription (val);
     }
-	else if ((param.empty())|| (param.front() == '#'))
-	{
-		// comment parameter meant to do nothing
-	}
+    else if ((param.empty())|| (param.front() == '#'))
+    {
+        // comment parameter meant to do nothing
+    }
     else
     {
         if (val == "true")
@@ -193,9 +193,9 @@ void coreObject::set (const std::string &param, const std::string &val)
                 LOG_WARNING("parameter " + param + " not found");
                 throw (unrecognizedParameter(param));
             }
-          
+
         }
-       
+
     }
 }
 
@@ -260,10 +260,10 @@ void coreObject::setFlag (const std::string &flag, bool val)
     {
         alert (this, UPDATE_REQUIRED);
     }
-	else if ((flag.empty()) || (flag.front() == '#'))
-	{
-		// comment parameter meant to do nothing
-	}
+    else if ((flag.empty()) || (flag.front() == '#'))
+    {
+        // comment parameter meant to do nothing
+    }
     else
     {
         auto lower = convertToLowerCase(flag);
@@ -345,10 +345,10 @@ void coreObject::set (const std::string &param, double val, gridUnits::units_t u
     {
         setUserID (static_cast<index_t> (val));
     }
-   else if ((param.empty()) || (param.front() == '#'))
-	{
-		// comment parameter meant to do nothing
-	}
+    else if ((param.empty()) || (param.front() == '#'))
+    {
+        // comment parameter meant to do nothing
+    }
     else
     {
         try

--- a/src/core/coreObject.h
+++ b/src/core/coreObject.h
@@ -51,7 +51,7 @@ class coreObject
 {
 private:
 	//this is used much more frequently than any other so it gets its own boolean at the beginning of the object
-	bool enabled = true;     //!< enabled indicator 
+	bool enabled = true;     //!< enabled indicator
 	bool updates_enabled = false; //!< indicator that updates are enabled
 protected:
 	bool extra_bool = false;  //!< an extra flag for derived classes to use
@@ -113,7 +113,7 @@ public:
   * @param[in] message the log message
   */
   virtual void log (coreObject *object, print_level level, const std::string &message);
-  
+
   /**
   * @brief increment the reference counter for the object
   */
@@ -317,7 +317,7 @@ public:
   {
     return nextUpdateTime;
   }
-  
+
   /**@brief return the last time the object had its state set or was updated
   */
   coreTime currentTime () const noexcept

--- a/src/formatInterpreters/jsonReaderElement.cpp
+++ b/src/formatInterpreters/jsonReaderElement.cpp
@@ -22,7 +22,7 @@ static const std::string nullStr = std::string ("");
 bool isElement (const Json_gd::Value &testValue);
 bool isAttribute (const Json_gd::Value &testValue);
 
-jsonReaderElement::jsonReaderElement () noexcept {}
+jsonReaderElement::jsonReaderElement () noexcept = default;
 jsonReaderElement::jsonReaderElement (const std::string &fileName) { jsonReaderElement::loadFile (fileName); }
 void jsonReaderElement::clear ()
 {

--- a/src/formatInterpreters/readerElement.cpp
+++ b/src/formatInterpreters/readerElement.cpp
@@ -13,7 +13,7 @@
 #include "readerElement.h"
 #include "utilities/stringConversion.h"
 
-readerAttribute::readerAttribute () {}
+readerAttribute::readerAttribute () = default;
 readerAttribute::readerAttribute (std::string attName, std::string attText) : name (std::move(attName)), text (std::move(attText)) {}
 void readerAttribute::set (const std::string &attName, const std::string &attText)
 {

--- a/src/formatInterpreters/tinyxml2ReaderElement.cpp
+++ b/src/formatInterpreters/tinyxml2ReaderElement.cpp
@@ -16,7 +16,7 @@
 
 using namespace tinyxml2;
 
-tinyxml2ReaderElement::tinyxml2ReaderElement () noexcept {}
+tinyxml2ReaderElement::tinyxml2ReaderElement () noexcept = default;
 tinyxml2ReaderElement::tinyxml2ReaderElement (const std::string &fileName) { tinyxml2ReaderElement::loadFile (fileName); }
 tinyxml2ReaderElement::tinyxml2ReaderElement (const XMLElement *xmlElement, const XMLElement *xmlParent)
     : element (xmlElement), parent (xmlParent)

--- a/src/formatInterpreters/tinyxmlReaderElement.cpp
+++ b/src/formatInterpreters/tinyxmlReaderElement.cpp
@@ -23,7 +23,7 @@
 
 #include "utilities/stringConversion.h"
 
-tinyxmlReaderElement::tinyxmlReaderElement () noexcept {}
+tinyxmlReaderElement::tinyxmlReaderElement () noexcept = default;
 tinyxmlReaderElement::tinyxmlReaderElement (const std::string &fileName) { loadFile (fileName); }
 tinyxmlReaderElement::tinyxmlReaderElement (const ticpp::Element *ticppElement, const ticpp::Element *ticppParent)
     : element (ticppElement), parent (ticppParent)
@@ -250,13 +250,9 @@ std::shared_ptr<readerElement> tinyxmlReaderElement::firstChild () const
     }
     if (child != nullptr)
     {
-        auto a = std::make_shared<tinyxmlReaderElement> (child, element);
-        return a;
+        return std::make_shared<tinyxmlReaderElement> (child, element);
     }
-    else
-    {
-        return nullptr;
-    }
+    return nullptr;
 }
 
 std::shared_ptr<readerElement> tinyxmlReaderElement::firstChild (const std::string &childName) const
@@ -274,10 +270,7 @@ std::shared_ptr<readerElement> tinyxmlReaderElement::firstChild (const std::stri
     {
         return std::make_shared<tinyxmlReaderElement> (child, element);
     }
-    else
-    {
-        return nullptr;
-    }
+    return nullptr;
 }
 
 void tinyxmlReaderElement::moveToNextSibling ()
@@ -333,7 +326,7 @@ void tinyxmlReaderElement::moveToParent ()
         element = parent;
         att = nullptr;
         auto temp = element->Parent (false);
-        if (temp)
+        if (temp != nullptr)
         {
             if (temp->Type () == TiXmlNode::ELEMENT)
             {

--- a/src/formatInterpreters/tomlElement.cpp
+++ b/src/formatInterpreters/tomlElement.cpp
@@ -12,7 +12,7 @@
 
 #include "tomlElement.h"
 
-static const std::string nullStr{ "" };
+static const std::string nullStr{};
 
 tomlElement::tomlElement (toml::Value vElement, std::string newName)
     : name (std::move (newName)), element (std::move (vElement))
@@ -38,4 +38,3 @@ void tomlElement::clear ()
     arraytype = false;
     name = nullStr;
 }
-

--- a/src/formatInterpreters/tomlElement.h
+++ b/src/formatInterpreters/tomlElement.h
@@ -20,11 +20,9 @@ public:
 	int elementIndex = 0;
 	std::string name;
 	int arrayIndex = 0;
-	tomlElement() noexcept
-	{
-	}
+	tomlElement() = default;
 	tomlElement(toml::Value vElement, std::string newName);
-	
+
 	void clear();
 	const toml::Value &getElement() const
 	{
@@ -43,5 +41,3 @@ private:
 	bool arraytype = false;
 
 };
-
-

--- a/src/formatInterpreters/tomlReaderElement.cpp
+++ b/src/formatInterpreters/tomlReaderElement.cpp
@@ -17,12 +17,12 @@
 #include <fstream>
 #include <iostream>
 
-static const std::string nullStr{ "" };
+static const std::string nullStr{};
 
 bool isElement (const toml::Value &testValue);
 bool isAttribute (const toml::Value &testValue);
 
-tomlReaderElement::tomlReaderElement () noexcept {}
+tomlReaderElement::tomlReaderElement () noexcept = default;
 tomlReaderElement::tomlReaderElement (const std::string &fileName) { tomlReaderElement::loadFile (fileName); }
 void tomlReaderElement::clear ()
 {
@@ -270,11 +270,7 @@ double tomlReaderElement::getAttributeValue (const std::string &attributeName) c
     {
         return v->asNumber();
     }
-    else
-    {
-        return numeric_conversionComplete(v->as<std::string>(), readerNullVal);
-    }
-
+    return numeric_conversionComplete(v->as<std::string>(), readerNullVal);
 }
 
 std::shared_ptr<readerElement> tomlReaderElement::firstChild () const
@@ -363,7 +359,7 @@ void tomlReaderElement::moveToNextSibling ()
         return;
     }
     // there are no more elements in a potential array
-   
+
     auto &tab = parents.back()->getElement().as<toml::Table>();
     auto elementIterator = tab.begin();
     auto elementEnd = tab.end();


### PR DESCRIPTION
 * use `= default;` where possible
 * fix whitespace