### PR TITLE
Fix most warnings in coupling, extraModels, fileInput

### DIFF
--- a/src/coupling/GhostSwingBusManager.cpp
+++ b/src/coupling/GhostSwingBusManager.cpp
@@ -80,14 +80,12 @@ GhostSwingBusManager::GhostSwingBusManager (int* argc, char **argv[])
 
   m_voltSendMessage.resize (m_numTasks);
   m_currReceiveMessage.resize (m_numTasks);
-
-  return;
 }
 
 GhostSwingBusManager::~GhostSwingBusManager() = default;
 
 // for Transmission
-int GhostSwingBusManager::createGridlabDInstance (string arguments)
+int GhostSwingBusManager::createGridlabDInstance (const string& arguments)
 {
   assert (arguments.size () <= PATH_MAX * 4); //there is a bug in Visual studio where the sizeof doesn't compile
 
@@ -177,12 +175,11 @@ void GhostSwingBusManager::sendVoltageStep (int taskId, cvec &voltage, unsigned 
 #else
 
   try {
-      dummy_load_eval[taskId](&(m_voltSendMessage[taskId]), &(m_currReceiveMessage[taskId]));
-    }
-  catch (std::bad_function_call)
-    {
-
-    }
+    dummy_load_eval[taskId](&(m_voltSendMessage[taskId]), &(m_currReceiveMessage[taskId]));
+  }
+  catch (const std::bad_function_call&)
+  {
+  }
 
 #endif
 }

--- a/src/coupling/GhostSwingBusManager.h
+++ b/src/coupling/GhostSwingBusManager.h
@@ -75,7 +75,7 @@ public:
    *
    * Returns taskId for the new instance.
    */
-  int createGridlabDInstance (std::string arguments);
+  int createGridlabDInstance (const std::string& arguments);
 
   /**
    * End the simulation.

--- a/src/extraModels/txLifeSpan.cpp
+++ b/src/extraModels/txLifeSpan.cpp
@@ -34,7 +34,7 @@ txLifeSpan::txLifeSpan(const std::string &objName):sensor(objName)
 
 coreObject * txLifeSpan::clone(coreObject *obj) const
 {
-	txLifeSpan *nobj = cloneBase<txLifeSpan, sensor>(this, obj);
+	auto *nobj = cloneBase<txLifeSpan, sensor>(this, obj);
 	if (nobj==nullptr)
 	{
 		return obj;
@@ -107,7 +107,7 @@ void txLifeSpan::set (const std::string &param, double val, units_t unitType)
 
 double txLifeSpan::get(const std::string & param, gridUnits::units_t unitType) const
 {
-	
+
 	return sensor::get(param, unitType);
 }
 
@@ -118,7 +118,7 @@ void txLifeSpan::add(coreObject * /*obj*/)
 
 void txLifeSpan::dynObjectInitializeA (coreTime time0, std::uint32_t flags)
 {
-	if (!(m_sourceObject))
+	if (m_sourceObject == nullptr)
 	{
 		return sensor::dynObjectInitializeA(time0, flags);
 	}
@@ -140,7 +140,7 @@ void txLifeSpan::dynObjectInitializeA (coreTime time0, std::uint32_t flags)
 	if (!opFlags[dyn_initialized])
 	{
 		sensor::setFlag("sampled", true);
-		if (inputStrings.size() == 0)
+		if (inputStrings.empty())
 		{
 			//assume we are connected to a temperature sensor
 			sensor::set("input0", "hot_spot");
@@ -155,9 +155,9 @@ void txLifeSpan::dynObjectInitializeA (coreTime time0, std::uint32_t flags)
 		auto g1 = std::make_shared<customGrabber>();
 		g1->setGrabberFunction("rate", [this](coreObject *)->double {return Faa; });
 		sensor::add(g1);
-		
+
 		sensor::set("output2", "input1");
-		if (m_sinkObject)
+		if (m_sinkObject != nullptr)
 		{
 			auto ge = std::make_unique<Event>();
 			ge->setTarget(m_sinkObject, "g");
@@ -184,7 +184,7 @@ void txLifeSpan::dynObjectInitializeA (coreTime time0, std::uint32_t flags)
 				setActionTrigger(2, 0);
 			}
 		}
-		
+
 	}
 	return sensor::dynObjectInitializeA(time0, flags);
 }
@@ -221,12 +221,12 @@ void txLifeSpan::updateA(coreTime time)
 void txLifeSpan::timestep(coreTime time, const IOdata & /*inputs*/, const solverMode & /*sMode*/)
 {
 	updateA(time);
-	
+
 }
 
 void txLifeSpan::actionTaken(index_t ActionNum, index_t /*conditionNum*/,  change_code /*actionReturn*/, coreTime /*actionTime*/)
 {
-	if (m_sinkObject)
+	if (m_sinkObject != nullptr)
 	{
 		if (ActionNum == 0)
 		{

--- a/src/extraModels/txLifeSpan.h
+++ b/src/extraModels/txLifeSpan.h
@@ -52,7 +52,7 @@ public:
 	virtual void timestep(coreTime time, const IOdata &inputs, const solverMode &sMode) override;
 	virtual void updateA(coreTime time) override;
 
-	void actionTaken(index_t conditionNum, index_t ActionNum, change_code actionReturn, coreTime /*actionTime*/) override;
+	void actionTaken(index_t ActionNum, index_t conditionNum, change_code actionReturn, coreTime /*actionTime*/) override;
 };
 
 }//namespace extra

--- a/src/extraModels/txThermalModel.cpp
+++ b/src/extraModels/txThermalModel.cpp
@@ -26,7 +26,7 @@
 
 namespace griddyn {
 namespace extra {
-txThermalModel::txThermalModel(const std::string &objName) :sensor(objName)
+txThermalModel::txThermalModel(const std::string &objName) : sensor(objName)
 {
 	opFlags.reset(continuous_flag);  //this is a not a continuous model
 	outputStrings = { {"ambient","ambientTemp","airTemp"}, {"top_oil","top_oil_temp"}, {"hot_spot","hot_spot_temp"} }; //preset the outputNames
@@ -35,7 +35,7 @@ txThermalModel::txThermalModel(const std::string &objName) :sensor(objName)
 
 coreObject * txThermalModel::clone(coreObject *obj) const
 {
-	txThermalModel *nobj = cloneBase<txThermalModel, sensor>(this, obj);
+	auto *nobj = cloneBase<txThermalModel, sensor>(this, obj);
 	if (nobj==nullptr)
 	{
 		return obj;
@@ -246,7 +246,7 @@ void txThermalModel::add(coreObject * /*obj*/)
 
 void txThermalModel::dynObjectInitializeA(coreTime time0, std::uint32_t flags)
 {
-	if (!(m_sourceObject))
+	if (m_sourceObject == nullptr)
 	{
 		return sensor::dynObjectInitializeA(time0, flags);
 	}

--- a/src/extraModels/txThermalModel.h
+++ b/src/extraModels/txThermalModel.h
@@ -43,10 +43,10 @@ protected:
 	double cutoutTemp = 0;  //!<[C] the temp at which the breakers are tripped
 	double alarmDelay = 300;  //!<[s] delay time on the alarms and cutout;
 private:
-	double rating;  //!< transformer rating
-	double Plossr;  //!<  the losses at rated power
-	double m_C;   //!< transformer thermal capacity
-	double m_k;   //!< transformer radiation constant
+	double rating = 0.0;  //!< transformer rating
+	double Plossr = 0.0;  //!<  the losses at rated power
+	double m_C = 0.0;   //!< transformer thermal capacity
+	double m_k = 0.0;   //!< transformer radiation constant
 public:
 	/** @brief constructor*/
 	txThermalModel(const std::string &objName="txThermal_$");

--- a/src/fileInput/gridDynReadCDF.cpp
+++ b/src/fileInput/gridDynReadCDF.cpp
@@ -540,7 +540,7 @@ void cdfReadBranch (coreObject *parentObject,
         lnk->set ("maxtapangle", X, deg);
         break;
     default:
-        printf ("unrecognized line code %d\n", code);
+        std::cout << "unrecognized line code " << std::to_string (code) << std::endl;
         return;
     }
 

--- a/src/fileInput/gridDynReadCSV.cpp
+++ b/src/fileInput/gridDynReadCSV.cpp
@@ -67,12 +67,8 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
             if (line[1] == '#')  // new section
             {
                 mState = read_header;
-                continue;
             }
-            else  // general comment line
-            {
-                continue;
-            }
+            continue;
         }
         if (mState == read_header)
         {
@@ -159,14 +155,15 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
             auto lineTokens = split (line);
             if (lineTokens.size () != headers.size ())
             {
-                fprintf (stderr, "line %d length does not match section header\n", lineNumber);
+                std::cerr << "line " << std::to_string (lineNumber)
+                          << " length does not match section header" << std::endl;
                 return;
             }
             // check the identifier
             auto ref = (refkey >= 0) ? trim (lineTokens[refkey]) : "";
             auto type = (typekey >= 0) ? trim (lineTokens[typekey]) : "";
             // find or create the object
-            int index = numeric_conversion<int> (lineTokens[0], -2);
+            auto index = numeric_conversion<int> (lineTokens[0], -2);
             coreObject *obj = nullptr;
             if (index >= 0)
             {
@@ -242,7 +239,7 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
                     auto str = trim (lineTokens[kk]).to_string ();
 
                     str = ri.checkDefines (str);
-                    double val = numeric_conversion (str, kBigNum);
+                    auto val = numeric_conversion<double> (str, kBigNum);
                     gridBus *bus = nullptr;
                     if (val < kHalfBigNum)
                     {
@@ -260,7 +257,7 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
                 else if ((field.compare (0, 4, "from") == 0) && (ObjectMode == "link"))
                 {
                     auto str = ri.checkDefines (trim (lineTokens[kk]).to_string ());
-                    double val = numeric_conversion (str, kBigNum);
+                    auto val = numeric_conversion<double> (str, kBigNum);
                     gridBus *bus = nullptr;
                     if (val < kHalfBigNum)
                     {
@@ -283,7 +280,7 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
                 else if ((field == "bus") && ((ObjectMode == "load") || (ObjectMode == "gen")))
                 {
                     auto str = ri.checkDefines (lineTokens[kk].to_string ());
-                    double val = numeric_conversion (str, kBigNum);
+                    auto val = numeric_conversion<double> (str, kBigNum);
                     gridBus *bus = nullptr;
                     if (val < kHalfBigNum)
                     {
@@ -344,7 +341,7 @@ void loadCSV (coreObject *parentObject, const std::string &fileName, readerInfo 
                 else
                 {
                     auto str = ri.checkDefines (trim (lineTokens[kk]).to_string ());
-                    double val = numeric_conversion (str, kBigNum);
+                    auto val = numeric_conversion<double> (str, kBigNum);
 
                     if (val < kHalfBigNum)
                     {

--- a/src/fileInput/gridDynReadPTI.cpp
+++ b/src/fileInput/gridDynReadPTI.cpp
@@ -366,7 +366,7 @@ void ptiReadBus (gridBus *bus, const std::string &line, basicReaderInfo &opt)
         {
           temp2 = opt.prefix + '_' + temp;
         }
-      else
+        else
         {
           temp2 = opt.prefix + '_' + temp2;
         }
@@ -537,8 +537,8 @@ void ptiReadGen (Generator *gen, const std::string &line, basicReaderInfo & /*op
     }
 
     // get the power generation
-    double p = numeric_conversion<double> (strvec[2], 0.0);
-    double q = numeric_conversion<double> (strvec[3], 0.0);
+    auto p = numeric_conversion<double> (strvec[2], 0.0);
+    auto q = numeric_conversion<double> (strvec[3], 0.0);
   if (p != 0.0)
     {
       gen->set ("p", p, MW);
@@ -558,7 +558,7 @@ void ptiReadGen (Generator *gen, const std::string &line, basicReaderInfo & /*op
     {
       gen->set ("qmin", q, MVAR);
     }
-    double V = numeric_conversion<double> (strvec[6], 0.0);
+    auto V = numeric_conversion<double> (strvec[6], 0.0);
   if (V > 0)
     {
       gen->set ("vset", V);

--- a/src/fileInput/gridDynReadRAW.cpp
+++ b/src/fileInput/gridDynReadRAW.cpp
@@ -225,12 +225,12 @@ void loadRAW (coreObject *parentObject, const std::string &fileName, const basic
                 busList[index]->setUserID (index);
 
                 rawReadBus (busList[index], line, opt);
-				auto tobj = parentObject->find(busList[index]->getName());
+                auto tobj = parentObject->find(busList[index]->getName());
                 if (tobj==nullptr)
                 {
                     parentObject->add (busList[index]);
                 }
-				else
+				            else
                 {
                     auto prevName = busList[index]->getName ();
                     busList[index]->setName (prevName + '_' +
@@ -583,7 +583,7 @@ void rawReadBus (gridBus *bus, const std::string &line, basicReaderInfo &opt)
         bus->disable ();
     }
     bus->set ("type", temp);
-	if (opt.version >= 31)
+    if (opt.version >= 31)
     {
         // skip the load flow area and loss zone for now
         // skip the owner information
@@ -948,13 +948,13 @@ void rawReadBranch (coreObject *parentObject,
         }
     }
 
-    double R = numeric_conversion (strvec[3], 0.0);
-    double X = numeric_conversion (strvec[4], 0.0);
+    auto R = numeric_conversion<double> (strvec[3], 0.0);
+    auto X = numeric_conversion<double> (strvec[4], 0.0);
     // get line impedances and resistance
     lnk->set ("r", R);
     lnk->set ("x", X);
     // get line capacitance
-    double val = numeric_conversion (strvec[5], 0.0);
+    auto val = numeric_conversion<double> (strvec[5], 0.0);
     lnk->set ("b", val);
 
     int status;
@@ -976,7 +976,7 @@ void rawReadBranch (coreObject *parentObject,
     }
     if (opt.version <= 26)  // transformers described in this section and in TX adj section
     {
-        val = numeric_conversion (strvec[9], 0.0);
+        val = numeric_conversion<double> (strvec[9], 0.0);
         if (val != 0.0)
         {
             lnk->set ("tap", val);
@@ -1264,8 +1264,8 @@ int rawReadTX (coreObject *parentObject, stringVec &txlines, std::vector<gridBus
 
     // get the branch impedance
 
-    double R = numeric_conversion<double> (strvec2[0], 0.0);
-    double X = numeric_conversion<double> (strvec2[1], 0.0);
+    auto R = numeric_conversion<double> (strvec2[0], 0.0);
+    auto X = numeric_conversion<double> (strvec2[1], 0.0);
 
     lnk->set ("r", R);
     lnk->set ("x", X);
@@ -1283,7 +1283,7 @@ int rawReadTX (coreObject *parentObject, stringVec &txlines, std::vector<gridBus
 
     // TODO:PT get the other parameters (not critical for power flow)
 
-    double val = numeric_conversion<double> (strvec3[0], 0.0);
+    auto val = numeric_conversion<double> (strvec3[0], 0.0);
     if (val != 0)
     {
         lnk->set ("tap", val);
@@ -1297,7 +1297,7 @@ int rawReadTX (coreObject *parentObject, stringVec &txlines, std::vector<gridBus
     // SGS set this for adjustable transformers....is this correct?
     if (abs (code) > 0)
     {
-        int cbus = numeric_conversion<int> (strvec3[7], 0);
+        auto cbus = numeric_conversion<int> (strvec3[7], 0);
         if (cbus != 0)
         {
             static_cast<links::adjustableTransformer *> (lnk)->setControlBus (busList[cbus]);
@@ -1373,16 +1373,16 @@ void rawReadSwitchedShunt (coreObject *parentObject,
         busList[index]->add (ld);
     }
 
-    int mode = numeric_conversion<int> (strvec[1], 0);
-	int shift = 0;
-	if (opt.version > 32)
-	{
+    auto mode = numeric_conversion<int> (strvec[1], 0);
+    int shift = 0;
+    if (opt.version > 32)
+    {
 		shift = 2;
-	}
-    double high = numeric_conversion<double> (strvec[2+shift], 0.0);
-    double low = numeric_conversion<double> (strvec[3+shift], 0.0);
+    }
+    auto high = numeric_conversion<double> (strvec[2+shift], 0.0);
+    auto low = numeric_conversion<double> (strvec[3+shift], 0.0);
     // get the controlled bus
-    int cbus = numeric_conversion<int> (strvec[4+shift], -1);
+    auto cbus = numeric_conversion<int> (strvec[4+shift], -1);
 
     if (cbus < 0)
     {
@@ -1499,10 +1499,10 @@ void rawReadSwitchedShunt (coreObject *parentObject,
     {
         start = 5;
     }
-	else if (opt.version > 32)
-	{
-		start = 9;
-	}
+    else if (opt.version > 32)
+    {
+        start = 9;
+    }
     size_t ksize = strvec.size () - 1;
     for (size_t kk = start + 1; kk < ksize; kk += 2)
     {

--- a/src/fileInput/gridDynRunner.cpp
+++ b/src/fileInput/gridDynRunner.cpp
@@ -58,7 +58,7 @@ int GriddynRunner::InitializeFromString(const std::string &cmdargs)
 
 int GriddynRunner::Initialize (int argc, char *argv[], readerInfo &ri, bool allowUnrecognized)
 {
-    
+
 
     if (!m_gds)
     {
@@ -88,7 +88,7 @@ int GriddynRunner::Initialize (int argc, char *argv[], readerInfo &ri, bool allo
         return (ret);
     }
     m_stopTime = std::chrono::high_resolution_clock::now ();
-    
+
 
     std::chrono::duration<double> elapsed_t = m_stopTime - m_startTime;
     m_gds->log (m_gds.get (), print_level::normal,
@@ -156,7 +156,7 @@ coreTime GriddynRunner::Run ()
 	{
 		throw(executionFailure(m_gds.get(), "asynchronous operation ongoing"));
 	}
-	
+
 		m_startTime = std::chrono::high_resolution_clock::now();
 		m_gds->run();
 		m_stopTime = std::chrono::high_resolution_clock::now();
@@ -164,7 +164,7 @@ coreTime GriddynRunner::Run ()
 		m_gds->log(m_gds.get(), print_level::summary,
 			m_gds->getName() + " executed in " + std::to_string(elapsed_t.count()) + " seconds");
 		return m_gds->getSimulationTime();
-	
+
 }
 
 
@@ -175,7 +175,7 @@ void GriddynRunner::RunAsync()
 		throw(executionFailure(m_gds.get(), "asynchronous operation ongoing"));
 	}
 	async_ret = std::async(std::launch::async, [this] {return Run(); });
-	
+
 }
 
 coreTime GriddynRunner::Step (coreTime time)
@@ -227,7 +227,7 @@ bool GriddynRunner::isReady() const
 
 int GriddynRunner::getStatus(coreTime &timeReturn)
 {
-	
+
 	timeReturn = m_gds->getSimulationTime();
 	return (isReady())?static_cast<int>(m_gds->currentProcessState()):GRIDDYN_PENDING;
 }
@@ -423,9 +423,9 @@ int argumentParser (int argc, char *argv[], po::variables_map &vm_map, bool allo
 
     // clang-format off
     // input boost controls
-    cmd_only.add_options () 
+    cmd_only.add_options ()
 		("help,h", "produce help message")
-		("config-file", po::value<std::string> (),"specify a configuration file to use") 
+		("config-file", po::value<std::string> (),"specify a configuration file to use")
 		("config-file-output", po::value<std::string> (), "file to store current configuration options")
 		("mpicount", "setup for an MPI run")
 		("version", "print version string")
@@ -471,15 +471,15 @@ int argumentParser (int argc, char *argv[], po::variables_map &vm_map, bool allo
     po::variables_map cmd_vm;
     try
     {
-        if (!allowUnrecognized)
-        {
-            po::store (po::command_line_parser (argc, argv).options (cmd_line).positional (p).run (), cmd_vm);
-        }
-        else
+        if (allowUnrecognized)
         {
             auto parsed =
               po::command_line_parser (argc, argv).options (cmd_line).positional (p).allow_unregistered ().run ();
             po::store (parsed, cmd_vm);
+        }
+        else
+        {
+            po::store (po::command_line_parser (argc, argv).options (cmd_line).positional (p).run (), cmd_vm);
         }
     }
     catch (std::exception &e)
@@ -505,15 +505,15 @@ int argumentParser (int argc, char *argv[], po::variables_map &vm_map, bool allo
         return 1;
     }
 
-    if (!allowUnrecognized)
-    {
-        po::store (po::command_line_parser (argc, argv).options (cmd_line).positional (p).run (), vm_map);
-    }
-    else
+    if (allowUnrecognized)
     {
         auto parsed =
           po::command_line_parser (argc, argv).options (cmd_line).positional (p).allow_unregistered ().run ();
         po::store (parsed, vm_map);
+    }
+    else
+    {
+        po::store (po::command_line_parser (argc, argv).options (cmd_line).positional (p).run (), vm_map);
     }
 
     if (cmd_vm.count ("config-file") > 0)

--- a/src/fileInput/gridDynRunner.h
+++ b/src/fileInput/gridDynRunner.h
@@ -23,7 +23,7 @@
 
 #ifndef GRIDDYN_PENDING
 #define GRIDDYN_PENDING (25)
-#endif 
+#endif
  //forward declaration for boost::program_options::variables_map
 namespace boost {
 namespace program_options {
@@ -58,10 +58,10 @@ public:
    * Initialize a simulation run from command line arguments.
    @param[in] argc the number of console arguments
    @param[in] argv the actual console arguments
-   @param[in] ignoreUnrecognized set to true to indicate that the unrecognized arguments should be ignored
+   @param[in] allowUnrecognized set to true to indicate that the unrecognized arguments should be allowed
    @return >0 normal stop,  0 normal, <0 error
    */
-  virtual int Initialize (int argc, char *argv[],bool ignoreUnrecognized);
+  virtual int Initialize (int argc, char *argv[], bool allowUnrecognized);
   /**
   * Initialize a simulation run from command line arguments using a given readerInfo structure
   @param[in] argc the number of console arguments
@@ -69,7 +69,7 @@ public:
   @param[in] ri the readerInfo structure that contains any additional reader information
   @return >0 normal stop,  0 normal, <0 error
   */
-  virtual int Initialize(int argc, char *argv[], readerInfo &ri,bool ignoreUnrecognized=false);
+  virtual int Initialize(int argc, char *argv[], readerInfo &ri, bool allowUnrecognized=false);
   /** initialization the simulation object so it is ready to run*/
   virtual void simInitialize();
   /**
@@ -179,4 +179,3 @@ int processCommandArguments (std::shared_ptr<gridDynSimulation> &gds, readerInfo
 
 }//namespace griddyn
 #endif
-

--- a/src/fileInput/gridReadEPC.cpp
+++ b/src/fileInput/gridReadEPC.cpp
@@ -501,7 +501,7 @@ System base, MVA
 double epcReadSolutionParamters (coreObject *parentObject, string_view line)
 {
     auto tokens = split (line, " ", delimiter_compression::on);
-    double val = numeric_conversion (tokens[1], 0.0);
+    auto val = numeric_conversion<double> (tokens[1], 0.0);
     if (tokens[0] == "tap")
     {
     }
@@ -567,13 +567,13 @@ void epcReadBus (gridBus *bus, string_view line, double /*base*/, const basicRea
     bus->setName (temp2);
 
     // get the localBaseVoltage
-    double bv = numeric_conversion<double> (strvec[2], -1.0);
+    auto bv = numeric_conversion<double> (strvec[2], -1.0);
     if (bv > 0.0)
     {
         bus->set ("basevoltage", bv);
     }
 
-    int type = numeric_conversion<int> (strvec[3], 1);
+    auto type = numeric_conversion<int> (strvec[3], 1);
 
     switch (type)
     {
@@ -595,13 +595,13 @@ void epcReadBus (gridBus *bus, string_view line, double /*base*/, const basicRea
     // skip the load flow area and loss zone for now
     // skip the owner information
     // get the voltage and angle specifications
-    double vm = numeric_conversion<double> (strvec[4], 0.0);
+    auto vm = numeric_conversion<double> (strvec[4], 0.0);
     if (vm != 0)
     {
         bus->set ("vtarget", vm);
     }
     vm = numeric_conversion<double> (strvec[5], 0.0);
-    double va = numeric_conversion<double> (strvec[6], 0.0);
+    auto va = numeric_conversion<double> (strvec[6], 0.0);
     if (va != 0)
     {
         bus->set ("angle", va, deg);
@@ -657,12 +657,12 @@ void epcReadDCBus (dcBus *bus, string_view line, double /*base*/, const basicRea
     bus->setName (temp2);
 
     // get the localBaseVoltage
-    double bv = numeric_conversion<double> (strvec[2], -1.0);
+    auto bv = numeric_conversion<double> (strvec[2], -1.0);
     if (bv > 0.0)
     {
         bus->set ("basevoltage", bv);
     }
-    int type = numeric_conversion<int> (strvec[3], 1);
+    auto type = numeric_conversion<int> (strvec[3], 1);
     switch (type)
     {
     case 1:
@@ -684,7 +684,7 @@ void epcReadDCBus (dcBus *bus, string_view line, double /*base*/, const basicRea
     // skip the load flow area and loss zone for now
     // skip the owner information
     // get the voltage and angle specifications
-    double vm = numeric_conversion<double> (strvec[7], 0.0);
+    auto vm = numeric_conversion<double> (strvec[7], 0.0);
     if (vm != 0)
     {
         bus->set ("v", vm);
@@ -725,8 +725,8 @@ void epcReadLoad (zipLoad *ld, string_view line, double /*base*/)
     // skip the area and zone information for now
 
     // get the constant power part of the load
-    double p = numeric_conversion<double> (strvec[6], 0.0);
-    double q = numeric_conversion<double> (strvec[7], 0.0);
+    auto p = numeric_conversion<double> (strvec[6], 0.0);
+    auto q = numeric_conversion<double> (strvec[7], 0.0);
     if (p != 0.0)
     {
         ld->set ("p", p, MW);
@@ -793,8 +793,8 @@ void epcReadFixedShunt (zipLoad *ld, string_view line, double /*base*/)
     // skip the area and zone information for now
 
     // get the constant power part of the load
-    double p = numeric_conversion<double> (strvec[13], 0.0);
-    double q = numeric_conversion<double> (strvec[14], 0.0);
+    auto p = numeric_conversion<double> (strvec[13], 0.0);
+    auto q = numeric_conversion<double> (strvec[14], 0.0);
     if (p != 0.0)
     {
         ld->set ("yp", p, puMW);
@@ -810,11 +810,11 @@ void epcReadSwitchShunt(loads::svd *ld, string_view line, double base)
 	auto strvec = splitlineBracket(line, " :", default_bracket_chars, delimiter_compression::on);
 
 
-	int mode = numeric_conversion<int>(strvec[1], 0);
-	double high = numeric_conversion<double>(strvec[12], 0.0);
-	double low = numeric_conversion<double>(strvec[13], 0.0);
+	auto mode = numeric_conversion<int>(strvec[1], 0);
+	auto high = numeric_conversion<double>(strvec[12], 0.0);
+	auto low = numeric_conversion<double>(strvec[13], 0.0);
 	// get the controlled bus
-	int cbus = numeric_conversion<int>(strvec[4], -1);
+	auto cbus = numeric_conversion<int>(strvec[4], -1);
 
 	/*
 	if (cbus < 0)
@@ -986,8 +986,8 @@ void epcReadGen (Generator *gen, string_view line, double /*base*/)
     }
 
     // get the power generation
-    double p = numeric_conversion<double> (strvec[13], 0.0);
-    double q = numeric_conversion<double> (strvec[16], 0.0);
+    auto p = numeric_conversion<double> (strvec[13], 0.0);
+    auto q = numeric_conversion<double> (strvec[16], 0.0);
     if (p != 0.0)
     {
         gen->set ("p", p, MW);
@@ -1019,7 +1019,7 @@ void epcReadGen (Generator *gen, string_view line, double /*base*/)
         gen->set ("qmin", q, MVAR);
     }
     // get the machine base
-    double mb = numeric_conversion<double> (strvec[19], 0.0);
+    auto mb = numeric_conversion<double> (strvec[19], 0.0);
     gen->set ("mbase", mb);
 
     mb = numeric_conversion<double> (strvec[22], 0.0);
@@ -1083,9 +1083,9 @@ void epcReadBranch (coreObject *parentObject,
 
     // get the name of the from bus
 
-    int ind1 = numeric_conversion<int> (strvec[0], 0);
+    auto ind1 = numeric_conversion<int> (strvec[0], 0);
 
-    int ind2 = numeric_conversion<int> (strvec[3], 0);
+    auto ind2 = numeric_conversion<int> (strvec[3], 0);
 
     gridBus *bus1 = busList[ind1 - 1];
     gridBus *bus2 = busList[ind2 - 1];
@@ -1112,8 +1112,8 @@ void epcReadBranch (coreObject *parentObject,
         lnk->disable ();
     }
 
-    double R = numeric_conversion<double> (strvec[10], 0.0);
-    double X = numeric_conversion<double> (strvec[11], 0.0);
+    auto R = numeric_conversion<double> (strvec[10], 0.0);
+    auto X = numeric_conversion<double> (strvec[11], 0.0);
 
     lnk->set ("r", R);
     lnk->set ("x", X);
@@ -1123,7 +1123,7 @@ void epcReadBranch (coreObject *parentObject,
     // get the branch impedance
 
     // get line capacitance
-    double val = numeric_conversion<double> (strvec[12], 0.0);
+    auto val = numeric_conversion<double> (strvec[12], 0.0);
     if (val != 0)
     {
         lnk->set ("b", val);
@@ -1166,9 +1166,9 @@ void epcReadDCBranch (coreObject *parentObject,
 
     // get the name of the from bus
 
-    int ind1 = numeric_conversion<int> (strvec[0], 0);
+    auto ind1 = numeric_conversion<int> (strvec[0], 0);
 
-    int ind2 = numeric_conversion<int> (strvec[3], 0);
+    auto ind2 = numeric_conversion<int> (strvec[3], 0);
 
     dcBus *bus1 = dcbusList[ind1 - 1];
     dcBus *bus2 = dcbusList[ind2 - 1];
@@ -1195,8 +1195,8 @@ void epcReadDCBranch (coreObject *parentObject,
         lnk->disable ();
     }
 
-    double R = numeric_conversion<double> (strvec[11], 0.0);
-    double X = numeric_conversion<double> (strvec[12], 0.0);
+    auto R = numeric_conversion<double> (strvec[11], 0.0);
+    auto X = numeric_conversion<double> (strvec[12], 0.0);
 
     lnk->set ("r", R);
     lnk->set ("x", X);
@@ -1212,7 +1212,7 @@ void epcReadDCBranch (coreObject *parentObject,
     {
         // lnk->set("b", val);
     }
-    double val = numeric_conversion<double> (strvec[14], 0.0);
+    auto val = numeric_conversion<double> (strvec[14], 0.0);
     if (val != 0)
     {
         lnk->set ("ratinga", val);
@@ -1249,9 +1249,9 @@ void epcReadTX (coreObject *parentObject,
     auto strvec = splitlineBracket (line, " :", default_bracket_chars, delimiter_compression::on);
     // get the name of the from bus
 
-    int ind1 = numeric_conversion<int> (strvec[0], 0);
+    auto ind1 = numeric_conversion<int> (strvec[0], 0);
 
-    int ind2 = numeric_conversion<int> (strvec[3], 0);
+    auto ind2 = numeric_conversion<int> (strvec[3], 0);
 
     gridBus *bus1 = busList[ind1 - 1];
     gridBus *bus2 = busList[ind2 - 1];
@@ -1312,8 +1312,8 @@ void epcReadTX (coreObject *parentObject,
     double tbase = base;
     tbase = numeric_conversion<double> (strvec[22], 0.0);
     // primary and secondary winding resistance
-    double R = numeric_conversion<double> (strvec[23], 0.0);
-    double X = numeric_conversion<double> (strvec[24], 0.0);
+    auto R = numeric_conversion<double> (strvec[23], 0.0);
+    auto X = numeric_conversion<double> (strvec[24], 0.0);
 
     lnk->set ("r", R * tbase / base);
     lnk->set ("x", X * tbase / base);

--- a/src/fileInput/gridReadMatPower.cpp
+++ b/src/fileInput/gridReadMatPower.cpp
@@ -108,7 +108,7 @@ void loadBusArray (coreObject *parentObject,
     loadFactory->prepObjects (static_cast<count_t> (buses.size ()), parentObject);
     for (const auto &busData : buses)
     {
-        index_t ind1 = static_cast<index_t> (busData[0]);
+        auto ind1 = static_cast<index_t> (busData[0]);
         if (ind1 >= static_cast<index_t> (busList.size ()))
         {
             busList.resize (ind1 * 2 + 1);
@@ -198,10 +198,10 @@ RAMP 10* 18 ramp rate for 10 minute reserves (MW)
 RAMP 30* 19 ramp rate for 30 minute reserves (MW)
 RAMP Q* 20 ramp rate for reactive power (2 sec timescale) (MVAr/min)
 APF* 21 area participation factor
-MU PMAX† 22 Kuhn-Tucker multiplier on upper Pg limit (u/MW)
-MU PMIN† 23 Kuhn-Tucker multiplier on lower Pg limit (u/MW)
-MU QMAX† 24 Kuhn-Tucker multiplier on upper Qg limit (u/MVAr)
-MU QMIN† 25 Kuhn-Tucker multiplier on lower Qg limit (u/MVAr)
+MU PMAXâ€  22 Kuhn-Tucker multiplier on upper Pg limit (u/MW)
+MU PMINâ€  23 Kuhn-Tucker multiplier on lower Pg limit (u/MW)
+MU QMAXâ€  24 Kuhn-Tucker multiplier on upper Qg limit (u/MVAr)
+MU QMINâ€  25 Kuhn-Tucker multiplier on lower Qg limit (u/MVAr)
 */
 
 int loadGenArray (coreObject *parentObject, mArray &gens, std::vector<gridBus *> &busList, const basicReaderInfo & bri)
@@ -375,7 +375,7 @@ void loadGenCostArray (coreObject *parentObject, mArray &genCost, int gencount)
     }
 }
 #else
-void loadGenCostArray (coreObject *, mArray & /*genCost*/, int /*gencount*/) {}
+void loadGenCostArray (coreObject * /*parentObject*/, mArray & /*genCost*/, int /*gencount*/) {}
 #endif
 /* Branch data
 F BUS 1 \from" bus number
@@ -393,14 +393,14 @@ SHIFT 10 transformer phase shift angle (degrees), positive ) delay
 BR STATUS 11 initial branch status, 1 = in-service, 0 = out-of-service
 ANGMIN* 12 minimum angle difference, ft (degrees)
 ANGMAX* 13 maximum angle difference, f t (degrees)
-PF† 14 real power injected at \from" bus end (MW)
-QF† 15 reactive power injected at \from" bus end (MVAr)
-PT† 16 real power injected at \to" bus end (MW)
-QT† 17 reactive power injected at \to" bus end (MVAr)
-MU SF‡ 18 Kuhn-Tucker multiplier on MVA limit at \from" bus (u/MVA)
-MU ST‡ 19 Kuhn-Tucker multiplier on MVA limit at \to" bus (u/MVA)
-MU ANGMIN‡ 20 Kuhn-Tucker multiplier lower angle dierence limit (u/degree)
-MU ANGMAX‡ 21 Kuhn-Tucker multiplier upper angle dierence limit (u/degree)
+PFâ€  14 real power injected at \from" bus end (MW)
+QFâ€  15 reactive power injected at \from" bus end (MVAr)
+PTâ€  16 real power injected at \to" bus end (MW)
+QTâ€  17 reactive power injected at \to" bus end (MVAr)
+MU SFâ€¡ 18 Kuhn-Tucker multiplier on MVA limit at \from" bus (u/MVA)
+MU STâ€¡ 19 Kuhn-Tucker multiplier on MVA limit at \to" bus (u/MVA)
+MU ANGMINâ€¡ 20 Kuhn-Tucker multiplier lower angle difference limit (u/degree)
+MU ANGMAXâ€¡ 21 Kuhn-Tucker multiplier upper angle difference limit (u/degree)
 */
 
 void loadLinkArray (coreObject *parentObject,

--- a/src/fileInput/gridReadPSAT.cpp
+++ b/src/fileInput/gridReadPSAT.cpp
@@ -65,7 +65,7 @@ void loadPsatBreakerArray (coreObject *parentObject, const mArray &brkr, const s
 void loadPsatSupplyArray (coreObject *parentObject, const mArray &genCost, const std::vector<gridBus *> &busList);
 void loadPsatMotorArray (coreObject *parentObject, const mArray &mtr, const std::vector<gridBus *> &busList);
 /** load a PSAT PMU data*/
-void loadPsatPmuArray(coreObject *parentObject, const mArray &mtr, const std::vector<gridBus *> &busList);
+void loadPsatPmuArray(coreObject *parentObject, const mArray &pmuData, const std::vector<gridBus *> &busList);
 void loadOtherObjectData (coreObject *parentObject,
                           const std::string &filetext,
                           const std::vector<gridBus *> &busList);
@@ -132,9 +132,10 @@ void loadPSAT (coreObject *parentObject, const std::string &filetext, const basi
     {
         if (!(bri.prefix.empty ()))
         {
+            std::string prefix_underscore = bri.prefix + '_';
             for (auto &vk : Vnames)
             {
-                vk = bri.prefix + '_' + vk;
+                vk = prefix_underscore.append(vk);
             }
         }
     }
@@ -217,7 +218,7 @@ void loadPSATBusArray (coreObject *parentObject,
             bus->setUserID (static_cast<int> (ind1));
             parentObject->add (bus);
         }
-        
+
 
         bus->set ("basevoltage", buses[kk][1]);
         if (buses[kk].size () > 2)
@@ -280,7 +281,7 @@ void loadPSATBusArray (coreObject *parentObject,
         {
         }
     }
-  
+
 	for (auto &pqInfo:PQ)
     {
         auto ind1 = static_cast<size_t> (pqInfo[0]);
@@ -465,7 +466,7 @@ void loadPSATLinkArray (coreObject *parentObject, const mArray &lnks, const std:
         lnk->updateBus (bus2, 2);
         parentObject->add (lnk);
 		bool tx = (lnkInfo[6] != 0.0);
-   
+
         if (tx)
         {
             lnk->set ("r", lnkInfo[7]);
@@ -524,7 +525,7 @@ void loadPSATLinkArrayB (coreObject *parentObject, const mArray &lnks, const std
         lnk->updateBus (bus2, 2);
         parentObject->add (lnk);
 		bool tx = (lnkInfo[6] != 0.0);
-      
+
         if (tx)
         {
             lnk->set ("r", lnkInfo[7]);
@@ -695,9 +696,9 @@ void loadPSATPHSArray (coreObject *parentObject, const mArray &phs, const std::v
 {
 	for (auto &phsInfo:phs)
     {
-        index_t ind1 = static_cast<index_t> (phsInfo[0]);
+        auto ind1 = static_cast<index_t> (phsInfo[0]);
         auto bus1 = busList[ind1];
-        index_t ind2 = static_cast<index_t> (phsInfo[1]);
+        auto ind2 = static_cast<index_t> (phsInfo[1]);
         auto bus2 = busList[ind2];
         auto lnk = new links::adjustableTransformer ();
 
@@ -763,7 +764,7 @@ void loadPSATSynArray (coreObject * /*parentObject*/, const mArray &syn, const s
 {
     using namespace genmodels;
 
-    
+
 
     int index = 1;
     for (auto genData : syn)
@@ -778,7 +779,8 @@ void loadPSATSynArray (coreObject * /*parentObject*/, const mArray &syn, const s
         gen->setUserID (index);
         ++index;
         auto mode = genData[4];
-		GenModel *gm = nullptr;
+
+        GenModel *gm = nullptr;
         if (mode < 2.1)  // second order classical model
         {
             gm = new GenModel ();
@@ -1005,7 +1007,7 @@ void loadPsatFaultArray (coreObject *parentObject, const mArray &fault, const st
 
 void loadPsatPmuArray(coreObject *parentObject, const mArray &pmuData, const std::vector<gridBus *> &busList)
 {
-	gridSimulation *gds = dynamic_cast<gridSimulation *> (parentObject->getRoot());
+	auto *gds = dynamic_cast<gridSimulation *> (parentObject->getRoot());
 	if (gds == nullptr)
 	{  // cant add the sensors if there is no simulation
 		return;
@@ -1034,8 +1036,8 @@ void loadPsatBreakerArray (coreObject *parentObject,
                            const mArray &brkr,
                            const std::vector<gridBus *> & /*busList*/)
 {
-   
-    gridSimulation *gds = dynamic_cast<gridSimulation *> (parentObject->getRoot ());
+
+    auto *gds = dynamic_cast<gridSimulation *> (parentObject->getRoot ());
     if (gds == nullptr)
     {  // cant make faults if we don't have access to the simulation
         return;

--- a/src/fileInput/gridReadPSAT.cpp
+++ b/src/fileInput/gridReadPSAT.cpp
@@ -132,10 +132,9 @@ void loadPSAT (coreObject *parentObject, const std::string &filetext, const basi
     {
         if (!(bri.prefix.empty ()))
         {
-            std::string prefix_underscore = bri.prefix + '_';
             for (auto &vk : Vnames)
             {
-                vk = prefix_underscore.append(vk);
+                bri.prefix + '_' + vk;
             }
         }
     }

--- a/src/fileInput/readConditionElement.cpp
+++ b/src/fileInput/readConditionElement.cpp
@@ -116,21 +116,21 @@ bool checkCondition (utilities::string_view cond, readerInfo &ri, coreObject *pa
         BlockB = (B == '=') ? trim (cond.substr (pos + 2)) : trim (cond.substr (pos + 1));
     }
 
-	ri.setKeyObject(parentObject);
+    ri.setKeyObject(parentObject);
     double aval = interpretString (BlockA.to_string (), ri);
     double bval = interpretString (BlockB.to_string (), ri);
 
-	if (!std::isnan(aval) && (!std::isnan(bval)))
-	{
-		try
-		{
-			eval = compare(aval, bval, A, B);
-		}
-		catch (const std::invalid_argument &)
-		{
-			WARNPRINT(READER_WARN_IMPORTANT, "invalid comparison operator");
-		}
-	}
+    if (!std::isnan(aval) && !std::isnan(bval))
+    {
+        try
+        {
+            eval = compare(aval, bval, A, B);
+        }
+        catch (const std::invalid_argument &)
+        {
+            WARNPRINT(READER_WARN_IMPORTANT, "invalid comparison operator");
+        }
+    }
     else if (std::isnan (aval) && (std::isnan (bval)))
     {  // do a string comparison
         std::string astr = ri.checkDefines (BlockA.to_string ());
@@ -150,7 +150,7 @@ bool checkCondition (utilities::string_view cond, readerInfo &ri, coreObject *pa
         WARNPRINT (READER_WARN_IMPORTANT, "invalid comparison terms");
     }
 
-	ri.setKeyObject(nullptr);
+    ri.setKeyObject(nullptr);
     return (rev) ? !eval : eval;
 }
 


### PR DESCRIPTION
Mostly fixing autos.

Other changes:
txLifeSpan.h
* ActionNum and conditionNum were in the wrong argument spots

gridDynRunner.cpp/h
 * ignoreUnrecognized -> allowUnrecognized, consistently

readElementFile.cpp
 * the diff is only removing the else and changing the indentation

Clang-tidy error metrics
 * before: 208
 * after: ~130~ 131