### PR TITLE
Cmake formatting

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,14 @@
+{
+  "line_width": 80,
+  "dangle_parens": true,
+  "command_case": "lower",
+  "separate_fn_name_with_space": false,
+  "always_wrap": [],
+  "separate_ctrl_name_with_space": false,
+  "max_subargs_per_line": 3,
+  "tab_size": 4,
+  "keyword_case": "upper",
+  "enum_char": ".",
+  "bullet_char": "*",
+  "line_ending": "unix"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,16 +29,16 @@ set(GRIDDYN_VERSION_STRING_SHORT "${GRIDDYN_VERSION}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-#-----------------------------------------------------------------------------
+# ------------------------------------------------------------
 # set the module path and include some common macros
-#-----------------------------------------------------------------------------
+# ------------------------------------------------------------
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/config/cmake/")
 include(extraMacros)
 include(CMakeDependentOption)
 #include(BuildType)
-#-----------------------------------------------------------------------------
+# ------------------------------------------------------------
 # set the install path to a local directory
-#-----------------------------------------------------------------------------
+# ------------------------------------------------------------
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	 if (WIN32)
 		if (MSYS)
@@ -130,17 +130,17 @@ if (VERSION_OPTION)
 	endif (MSVC)
 endif(VERSION_OPTION)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # BOOST  find the boost libraries
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 set(BOOST_REQUIRED_LIBRARIES program_options unit_test_framework filesystem system date_time timer chrono)
 include(addBoost)
 set(GRIDDYN_BOOST_VERSION_LEVEL ${BOOST_VERSION_LEVEL})
 target_link_libraries(griddyn_base INTERFACE Boostlibs::core)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # add coverage target
-# -------------------------------------------------------------
+# ------------------------------------------------------------
  option (TEST_CODE_COVERAGE "Build a target for testing code coverage" OFF)
  if (TEST_CODE_COVERAGE)
   if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
@@ -157,9 +157,9 @@ target_link_libraries(griddyn_base INTERFACE Boostlibs::core)
  endif(TEST_CODE_COVERAGE)
 
  include(GNUInstallDirs)
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Get some configuration for C++17 as that becomes available
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 #message(STATUS ${CMAKE_CXX_FLAGS})
 set(CONFIGURE_TARGET_LOCATION ${AUTOBUILD_INSTALL_PATH}/include/griddyn/)
@@ -168,13 +168,10 @@ install(FILES ${AUTOBUILD_INSTALL_PATH}/include/griddyn/compiler-config.h DESTIN
 
 include(ExternalProject)
 
-
-#########################################################################################
-
 #include(mergestaticlibs)
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable OpenMP support?
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 option(OPENMP_ENABLE "Enable openMP support" OFF)
 else()
@@ -208,9 +205,9 @@ endif(OPENMP_FOUND)
 option(DISABLE_MULTITHREADING "disable multithreading in GridDyn libraries" OFF)
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Find multithreading headers and includes
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 if (NOT DISABLE_MULTITHREADING)
 	if (NOT WIN32)
@@ -222,9 +219,9 @@ if (NOT DISABLE_MULTITHREADING)
 	target_link_libraries(griddyn_base INTERFACE Threads::Threads)
 endif(NOT DISABLE_MULTITHREADING)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # finding MPI
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(MPI_ENABLE "Enable MPI networking library" OFF)
 if (MPI_ENABLE)
@@ -244,9 +241,9 @@ if (BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY)
 message(fatal "BOTH BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY cannot be specified together otherwise nothing works")
 endif()
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Find (and test) the KLU libraries
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(DISABLE_KLU "disable KLU (not recommended [slow], turn on AUTOBUILD_KLU if your system doesn't have SuiteSparse installed)" OFF)
 
@@ -256,9 +253,9 @@ else()
     set(KLU_ENABLE OFF CACHE BOOL "Disable KLU support" FORCE)
 endif()
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Sundials
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 include(addSundials)
 set(optional_component_test_files)
@@ -269,9 +266,9 @@ set (optional_library_functions )
 
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # setting the RPATH
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
@@ -305,9 +302,9 @@ if (NOT Boost_USE_STATIC_LIBS)
 endif()
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # global include directories
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 target_include_directories(griddyn_base INTERFACE
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 	$<BUILD_INTERFACE:${AUTOBUILD_INSTALL_PATH}/include>
@@ -319,9 +316,9 @@ target_include_directories(griddyn_base SYSTEM INTERFACE
 	$<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
 )
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # load the required subdirectories
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 add_subdirectory(src/formatInterpreters)
 
@@ -336,9 +333,9 @@ add_subdirectory(src/griddyn)
 
 add_library(griddyn_optional INTERFACE)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable support for Plugins
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(ENABLE_PLUGINS "Enable support for plugin modules" OFF)
 
@@ -352,9 +349,9 @@ if (ENABLE_PLUGINS)
 	endif()
 endif(ENABLE_PLUGINS)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable compilation of extraModels?
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(LOAD_EXTRA_MODELS "Compile and load extraModels" ON)
 # If extra models are used enabled try to locate the libraries
@@ -365,9 +362,9 @@ if (LOAD_EXTRA_MODELS)
   target_link_libraries(griddyn_optional INTERFACE extraModelLibrary)
 endif(LOAD_EXTRA_MODELS)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable compilation of extraSolvers?
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(LOAD_EXTRA_SOLVERS "Compile and load extraSolvers" OFF)
 # If extra solvers are used enabled try to locate the libraries
@@ -378,9 +375,9 @@ if (LOAD_EXTRA_SOLVERS)
   target_link_libraries(griddyn_optional INTERFACE extraSolverLibrary)
 endif(LOAD_EXTRA_SOLVERS)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable FMI support?
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(FMI_ENABLE "Enable FMI support" ON)
 
@@ -397,9 +394,9 @@ if (FMI_ENABLE)
 endif(FMI_ENABLE)
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # FSKIT
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(FSKIT_ENABLE "Enable FSKIT support" OFF)
 
@@ -409,9 +406,9 @@ if(FSKIT_ENABLE)
   target_link_libraries(griddyn_optional INTERFACE fskitLibrary)
 endif(FSKIT_ENABLE)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable 64 bit indexing (enable to allow for more than 2^31 objects)--that would be a very big model
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
   option(ENABLE_64_BIT_INDEXING "set all indexing and count variables to 64 bit unsigned (Usually not required)" OFF)
@@ -420,7 +417,7 @@ endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
 
 # ------------------------------------------------------------
 # Enable message logging
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 option(GRIDDYN_DISABLE_LOGGING "disable all normal, debug, and trace logging in GridDyn" OFF)
 if (NOT DISABLE_LOGGING)
 option(GRIDDYN_DISABLE_TRACE_LOGGING "disable trace logging" OFF)
@@ -444,9 +441,9 @@ endif(DOXYGEN_FOUND)
 endif (GRIDDYN_GENERATE_DOXYGEN_DOC)
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable HELICS executable
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(HELICS_EXECUTABLE "Enable the HELICS executable to be built" OFF)
 # If HELICS_EXECUTABLE is load the helics directory
@@ -460,9 +457,9 @@ else(HELICS_EXECUTABLE)
 	HIDE_VARIABLE(HELICS_INSTALL_PATH)
 endif(HELICS_EXECUTABLE)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable ZMQ interfacing
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(ENABLE_NETWORKING_LIBRARY "Enable network based communiation components" OFF)
 
@@ -498,9 +495,9 @@ endif(HELICS_EXECUTABLE)
 
 file(GLOB KEY_LIBRARY_FILES  ${PROJECT_BINARY_DIR}/libs/bin/*)
 message(STATUS "key files ${KEY_LIBRARY_FILES}")
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # load the subdirectories
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 
 
@@ -534,18 +531,18 @@ install(TARGETS griddyn_base griddyn_optional
 	EXPORT griddyn-targets
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	COMPONENT libraries)
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable clang analysis and formatting tools
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(ENABLE_CLANG_TOOLS "if clang is found enable some custom targets for clang formatting and tidy" OFF)
 
 if (ENABLE_CLANG_TOOLS)
 include(clang-cxx-dev-tools)
 endif(ENABLE_CLANG_TOOLS)
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Enable testCore construction?
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 option(TEST_ENABLE "Enable unit testing construction" ON)
 
@@ -568,9 +565,9 @@ install(DIRECTORY examples/ DESTINATION examples COMPONENT examples)
 #install(FILES ${ebraidfiles} DESTINATION examples/braid_examples COMPONENT examples)
 
 set(binfiles bin/configure.griddyn bin/pgriddyn bin/pgriddyn_debug)
-install(PROGRAMS ${binfiles} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
+install(PROGRAMS ${binfiles} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
 
-install(FILES ${KEY_LIBRARY_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
+install(FILES ${KEY_LIBRARY_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
 
 install (EXPORT griddyn-targets
 	NAMESPACE Griddyn::
@@ -578,18 +575,18 @@ install (EXPORT griddyn-targets
 	COMPONENT libs
 	)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # Future Additions
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 #adding dlls
 # install(FILES ${LOCATION_OF_FILES} DESTINATION bin)
 #file(GLOB docs "docs/manuals/*")
 #install(FILES ${docs} DESTINATION docs)
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # CTest
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 
 if(TEST_ENABLE)
     include(CTest)
@@ -621,9 +618,9 @@ if(TEST_ENABLE)
     endif()
 endif()
 
-#####################################################
-#########swig interface builds ######################
-#####################################################
+# ------------------------------------------------------------
+# swig interface builds
+# ------------------------------------------------------------
 
 if (INTERFACE_BUILD)
 	add_subdirectory(swig)
@@ -631,9 +628,9 @@ endif()
 
 
 
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 # CPack
-# -------------------------------------------------------------
+# ------------------------------------------------------------
 option(ENABLE_PACKAGE_BUILD "Add projects for making packages and installers for HELICS" OFF)
 
 if(ENABLE_PACKAGE_BUILD)
@@ -645,7 +642,7 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${GRIDDYN_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${GRIDDYN_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${GRIDDYN_VERSION_PATCH})
 
-set(CPACK_COMPONENTS_ALL applications headers libs runtime matlab python java octave examples)
+set(CPACK_COMPONENTS_ALL applications headers libs binaries matlab python java octave examples)
 
 if (WIN32)
 	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}\\\\LICENSE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,21 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(VERSION 3.5)
 
-#project name
+# project name
 project(GRIDDYN VERSION 0.9.0)
 
-#version number
-set(GRIDDYN_VERSION_BUILD )
-set (GRIDDYN_VERSION_UNDERSCORE "${GRIDDYN_VERSION_MAJOR}_${GRIDDYN_VERSION_MINOR}_${GRIDDYN_VERSION_PATCH}")
-if (GRIDDYN_VERSION_BUILD)
-	set(GRIDDYN_VERSION ${GRIDDYN_VERSION}-${GRIDDYN_VERSION_BUILD})
-	set (GRIDDYN_VERSION_UNDERSCORE "${GRIDDYN_VERSION_UNDERSCORE}-${GRIDDYN_VERSION_BUILD}")
+# version number
+set(GRIDDYN_VERSION_BUILD)
+set(
+    GRIDDYN_VERSION_UNDERSCORE
+    "${GRIDDYN_VERSION_MAJOR}_${GRIDDYN_VERSION_MINOR}_${GRIDDYN_VERSION_PATCH}"
+)
+if(GRIDDYN_VERSION_BUILD)
+    set(GRIDDYN_VERSION ${GRIDDYN_VERSION}-${GRIDDYN_VERSION_BUILD})
+    set(
+        GRIDDYN_VERSION_UNDERSCORE
+        "${GRIDDYN_VERSION_UNDERSCORE}-${GRIDDYN_VERSION_BUILD}"
+    )
 endif()
 
 set(GRIDDYN_DATE 4-28-2018)
@@ -32,26 +38,42 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # ------------------------------------------------------------
 # set the module path and include some common macros
 # ------------------------------------------------------------
-set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/config/cmake/")
+set(
+    CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/config/cmake/"
+)
 include(extraMacros)
 include(CMakeDependentOption)
-#include(BuildType)
+# include(BuildType)
 # ------------------------------------------------------------
 # set the install path to a local directory
 # ------------------------------------------------------------
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	 if (WIN32)
-		if (MSYS)
-				set (CMAKE_INSTALL_PREFIX "/usr/local/griddyn_${GRIDDYN_VERSION_UNDERSCORE}/" CACHE PATH "default install path" FORCE )
-		else(MSYS)
-			set (CMAKE_INSTALL_PREFIX "C:/local/griddyn_${GRIDDYN_VERSION_UNDERSCORE}/" CACHE PATH "default install path" FORCE )
-		endif(MSYS)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    if(WIN32)
+        if(MSYS)
+            set(
+                CMAKE_INSTALL_PREFIX
+                "/usr/local/griddyn_${GRIDDYN_VERSION_UNDERSCORE}/"
+                CACHE PATH "default install path"
+                FORCE
+            )
+        else(MSYS)
+            set(
+                CMAKE_INSTALL_PREFIX
+                "C:/local/griddyn_${GRIDDYN_VERSION_UNDERSCORE}/"
+                CACHE PATH "default install path"
+                FORCE
+            )
+        endif(MSYS)
 
-	endif(WIN32)
+    endif(WIN32)
 endif()
 
-SHOW_VARIABLE(AUTOBUILD_INSTALL_PATH PATH
-  "location to install the autobuild libraries and Headers" "${PROJECT_BINARY_DIR}/libs")
+show_variable(
+    AUTOBUILD_INSTALL_PATH
+    PATH
+    "location to install the autobuild libraries and Headers"
+    "${PROJECT_BINARY_DIR}/libs"
+)
 
 mark_as_advanced(AUTOBUILD_INSTALL_PATH)
 
@@ -62,59 +84,103 @@ file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/logs)
 
 # Prohibit in-source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-  message(FATAL_ERROR "In-source build is not supported. Please, use an empty directory for building the project.")
+    message(
+        FATAL_ERROR
+            "In-source build is not supported. Please, use an empty directory for building the project."
+    )
 endif()
 
 option(BUILD_HELICS_TESTS "Enable the test Executables to be built" ON)
 # enable testing
-if (BUILD_HELICS_TESTS)
-	enable_testing ()
+if(BUILD_HELICS_TESTS)
+    enable_testing()
 endif(BUILD_HELICS_TESTS)
 
-#add a baseline library for underlying dependencies and flags
+# add a baseline library for underlying dependencies and flags
 add_library(griddyn_base INTERFACE)
 
-option(ENABLE_EXTRA_COMPILER_WARNINGS "disable compiler warning for GridDyn build" ON)
+option(
+    ENABLE_EXTRA_COMPILER_WARNINGS "disable compiler warning for GridDyn build"
+    ON
+)
 
-SHOW_VARIABLE(COMPILER_OPTIMIZATION_LEVEL STRING
-  "set the optimization level for the compiler (not implemented yet)" "normal")
+show_variable(
+    COMPILER_OPTIMIZATION_LEVEL
+    STRING
+    "set the optimization level for the compiler (not implemented yet)"
+    "normal"
+)
 
-  set(optimization_levels normal;high;machine;full)
+set(optimization_levels normal;high;machine;full)
 
-set_property(CACHE COMPILER_OPTIMIZATION_LEVEL PROPERTY STRINGS ${optimization_levels})
+set_property(
+    CACHE COMPILER_OPTIMIZATION_LEVEL
+    PROPERTY STRINGS ${optimization_levels}
+)
 
-option(BUILD_SHARED_FMI_LIBRARY "Enable construction of a binary fmi shared library for GridDyn" OFF)
+option(
+    BUILD_SHARED_FMI_LIBRARY
+    "Enable construction of a binary fmi shared library for GridDyn" OFF
+)
 
-if (NOT CMAKE_DEBUG_POSTFIX)
-	set(CMAKE_DEBUG_POSTFIX d)
+if(NOT CMAKE_DEBUG_POSTFIX)
+    set(CMAKE_DEBUG_POSTFIX d)
 endif()
 
-
 option(BUILD_PYTHON_INTERFACE "Build Python extension" OFF)
-option(BUILD_PYTHON2_INTERFACE "Build Python2.7 extension(Requires swig and will not build if \"PYTHON_INTERFACE\" is active)" OFF)
+option(
+    BUILD_PYTHON2_INTERFACE
+    "Build Python2.7 extension(Requires swig and will not build if \"PYTHON_INTERFACE\" is active)"
+    OFF
+)
 option(BUILD_MATLAB_INTERFACE "Build Matlab Extension" OFF)
 option(BUILD_OCTAVE_INTERFACE "Build Octave extension (very experimental)" OFF)
 option(BUILD_JAVA_INTERFACE "Build Java extension" OFF)
 
-if (BUILD_PYTHON_INTERFACE OR BUILD_PYTHON2_INTERFACE OR BUILD_MATLAB_INTERFACE OR BUILD_JAVA_INTERFACE OR BUILD_OCTAVE_INTERFACE)
-	set(INTERFACE_BUILD ON)
-	HIDE_VARIABLE(BUILD_GRIDDYN_SHARED_LIBRARY)
-	SHOW_VARIABLE(DISABLE_SWIG BOOL "Disable the use of swig to generate interface code and use repo code" OFF)
+if(
+    BUILD_PYTHON_INTERFACE
+    OR BUILD_PYTHON2_INTERFACE
+    OR BUILD_MATLAB_INTERFACE
+    OR BUILD_JAVA_INTERFACE
+    OR BUILD_OCTAVE_INTERFACE
+)
+    set(INTERFACE_BUILD ON)
+    hide_variable(BUILD_GRIDDYN_SHARED_LIBRARY)
+    show_variable(
+        DISABLE_SWIG
+        BOOL
+        "Disable the use of swig to generate interface code and use repo code"
+        OFF
+    )
 else()
-	set(INTERFACE_BUILD OFF)
-	HIDE_VARIABLE(DISABLE_SWIG)
-	SHOW_VARIABLE(BUILD_GRIDDYN_SHARED_LIBRARY BOOL "Enable construction of GridDyn binary C based shared library" OFF)
+    set(INTERFACE_BUILD OFF)
+    hide_variable(DISABLE_SWIG)
+    show_variable(
+        BUILD_GRIDDYN_SHARED_LIBRARY
+        BOOL
+        "Enable construction of GridDyn binary C based shared library"
+        OFF
+    )
 endif()
 
 option(BUILD_CXX_SHARED_LIB "Build a Shared Libraries of the CXX interface" OFF)
 mark_as_advanced(BUILD_CXX_SHARED_LIB)
 
-if (INTERFACE_BUILD OR BUILD_GRIDDYN_SHARED_LIBRARY OR BUILD_CXX_SHARED_LIB OR BUILD_SHARED_FMI_LIBRARY)
-	set(BUILD_SHARED_LIBS ON)
+if(
+    INTERFACE_BUILD
+    OR BUILD_GRIDDYN_SHARED_LIBRARY
+    OR BUILD_CXX_SHARED_LIB
+    OR BUILD_SHARED_FMI_LIBRARY
+)
+    set(BUILD_SHARED_LIBS ON)
 endif()
-cmake_dependent_option(USE_POSITION_INDEPENDENT_CODE "Build the libraries with Position independent code Useful if only building the static library and it will be used later in a shared library" OFF "NOT BUILD_SHARED_LIBS" OFF)
-
-
+cmake_dependent_option(
+    USE_POSITION_INDEPENDENT_CODE
+    "Build the libraries with Position independent code Useful if only building the static library and it will be used later in a shared library"
+    OFF
+    "NOT BUILD_SHARED_LIBS"
+    OFF
+)
 
 if(BUILD_SHARED_LIBS OR USE_POSITION_INDEPENDENT_CODE)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -122,18 +188,30 @@ endif()
 
 include(compiler_flags)
 
-if (VERSION_OPTION)
-	if (MSVC)
-		target_compile_options(griddyn_base INTERFACE ${VERSION_OPTION})
-	else()
-		target_compile_options(griddyn_base INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>)
-	endif (MSVC)
+if(VERSION_OPTION)
+    if(MSVC)
+        target_compile_options(griddyn_base INTERFACE ${VERSION_OPTION})
+    else()
+        target_compile_options(
+            griddyn_base
+            INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>
+        )
+    endif(MSVC)
 endif(VERSION_OPTION)
 
 # ------------------------------------------------------------
 # BOOST  find the boost libraries
 # ------------------------------------------------------------
-set(BOOST_REQUIRED_LIBRARIES program_options unit_test_framework filesystem system date_time timer chrono)
+set(
+    BOOST_REQUIRED_LIBRARIES
+    program_options
+    unit_test_framework
+    filesystem
+    system
+    date_time
+    timer
+    chrono
+)
 include(addBoost)
 set(GRIDDYN_BOOST_VERSION_LEVEL ${BOOST_VERSION_LEVEL})
 target_link_libraries(griddyn_base INTERFACE Boostlibs::core)
@@ -141,82 +219,106 @@ target_link_libraries(griddyn_base INTERFACE Boostlibs::core)
 # ------------------------------------------------------------
 # add coverage target
 # ------------------------------------------------------------
- option (TEST_CODE_COVERAGE "Build a target for testing code coverage" OFF)
- if (TEST_CODE_COVERAGE)
-  if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
-   include(CodeCoverage)
+option(TEST_CODE_COVERAGE "Build a target for testing code coverage" OFF)
+if(TEST_CODE_COVERAGE)
+    if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+        include(CodeCoverage)
 
-   set(COVERAGE_EXCLUDES 'usr/*' 'dependencies/*' 'ThirdParty/*' 'test/*' 'tests/*' 'swig/*' 'examples/*')
-    SETUP_TARGET_FOR_COVERAGE(
-       NAME griddyn_coverage                    # New target name
-       EXECUTABLE ctest -R testShared # Executable in PROJECT_BINARY_DIR
-	  )
-  else()
-   message(FATAL_ERROR "CMAKE_BUILD_TYPE must be set to Coverage for testing code coverage")
-  endif()
- endif(TEST_CODE_COVERAGE)
+        set(
+            COVERAGE_EXCLUDES
+            'usr/*'
+            'dependencies/*'
+            'ThirdParty/*'
+            'test/*'
+            'tests/*'
+            'swig/*'
+            'examples/*'
+        )
+        setup_target_for_coverage(
+            NAME
+            griddyn_coverage # New target name
+            EXECUTABLE
+            ctest
+            -R
+            testShared # Executable in PROJECT_BINARY_DIR
+        )
+    else()
+        message(
+            FATAL_ERROR
+                "CMAKE_BUILD_TYPE must be set to Coverage for testing code coverage"
+        )
+    endif()
+endif(TEST_CODE_COVERAGE)
 
- include(GNUInstallDirs)
+include(GNUInstallDirs)
 # ------------------------------------------------------------
 # Get some configuration for C++17 as that becomes available
 # ------------------------------------------------------------
 
-#message(STATUS ${CMAKE_CXX_FLAGS})
+# message(STATUS ${CMAKE_CXX_FLAGS})
 set(CONFIGURE_TARGET_LOCATION ${AUTOBUILD_INSTALL_PATH}/include/griddyn/)
 include(configGenerator)
-install(FILES ${AUTOBUILD_INSTALL_PATH}/include/griddyn/compiler-config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn COMPONENT headers)
+install(
+    FILES ${AUTOBUILD_INSTALL_PATH}/include/griddyn/compiler-config.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)
 
 include(ExternalProject)
 
-#include(mergestaticlibs)
+# include(mergestaticlibs)
 # ------------------------------------------------------------
 # Enable OpenMP support?
 # ------------------------------------------------------------
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-option(OPENMP_ENABLE "Enable openMP support" OFF)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    option(OPENMP_ENABLE "Enable openMP support" OFF)
 else()
-option(OPENMP_ENABLE "Enable openMP support" ON)
+    option(OPENMP_ENABLE "Enable openMP support" ON)
 endif()
 
-
 if(OPENMP_ENABLE)
-  #message(STATUS "****** finding OpenMP support")
-  FIND_PACKAGE(OpenMP)
-  if(OPENMP_FOUND)
-      if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9")
-      link_libraries(OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
-    else()
-      add_compile_options($<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}> $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
-      link_libraries(${OpenMP_C_FLAGS})
-    endif()
-  else(OPENMP_FOUND)
-    message(STATUS "Disabling OpenMP support, could not determine compiler flags")
-	set(OPENMP_ENABLE FALSE)
-  endif(OPENMP_FOUND)
+    # message(STATUS "****** finding OpenMP support")
+    find_package(OpenMP)
+    if(OPENMP_FOUND)
+        if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9")
+            link_libraries(OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
+        else()
+            add_compile_options(
+                $<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>
+                $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>
+            )
+            link_libraries(${OpenMP_C_FLAGS})
+        endif()
+    else(OPENMP_FOUND)
+        message(
+            STATUS
+                "Disabling OpenMP support, could not determine compiler flags"
+        )
+        set(OPENMP_ENABLE FALSE)
+    endif(OPENMP_FOUND)
 else(OPENMP_ENABLE)
-  set(OPENMP_FOUND FALSE)
+    set(OPENMP_FOUND FALSE)
 endif(OPENMP_ENABLE)
 
-if (OPENMP_FOUND)
-	option(SUNDIALS_OPENMP "Enable SUNDIALS NVector openMP implementation" ON)
-	option(GRIDDYN_OPENMP "Enable openmp internal to GridDyn--not used yet" OFF)
+if(OPENMP_FOUND)
+    option(SUNDIALS_OPENMP "Enable SUNDIALS NVector openMP implementation" ON)
+    option(GRIDDYN_OPENMP "Enable openmp internal to GridDyn--not used yet" OFF)
 endif(OPENMP_FOUND)
 
 option(DISABLE_MULTITHREADING "disable multithreading in GridDyn libraries" OFF)
-
 
 # ------------------------------------------------------------
 # Find multithreading headers and includes
 # ------------------------------------------------------------
 
-if (NOT DISABLE_MULTITHREADING)
-	if (NOT WIN32)
-		set(THREADS_PREFER_PTHREAD_FLAG ON)
-	elseif (MSYS)
-		set(THREADS_PREFER_PTHREAD_FLAG ON)
-	endif()
-	find_package(Threads REQUIRED)
-	target_link_libraries(griddyn_base INTERFACE Threads::Threads)
+if(NOT DISABLE_MULTITHREADING)
+    if(NOT WIN32)
+        set(THREADS_PREFER_PTHREAD_FLAG ON)
+    elseif(MSYS)
+        set(THREADS_PREFER_PTHREAD_FLAG ON)
+    endif()
+    find_package(Threads REQUIRED)
+    target_link_libraries(griddyn_base INTERFACE Threads::Threads)
 endif(NOT DISABLE_MULTITHREADING)
 
 # ------------------------------------------------------------
@@ -224,28 +326,35 @@ endif(NOT DISABLE_MULTITHREADING)
 # ------------------------------------------------------------
 
 option(MPI_ENABLE "Enable MPI networking library" OFF)
-if (MPI_ENABLE)
-	include(addMPI)
-	if (TARGET MPI::MPI_C)
-		set(GRIDDYN_HAVE_MPI TRUE)
-		target_link_libraries(griddyn_base INTERFACE MPI::MPI_C)
-	else()
-		set(GRIDDYN_HAVE_MPI FALSE)
-	endif ()
+if(MPI_ENABLE)
+    include(addMPI)
+    if(TARGET MPI::MPI_C)
+        set(GRIDDYN_HAVE_MPI TRUE)
+        target_link_libraries(griddyn_base INTERFACE MPI::MPI_C)
+    else()
+        set(GRIDDYN_HAVE_MPI FALSE)
+    endif()
 else(MPI_ENABLE)
-	set(GRIDDYN_HAVE_MPI FALSE)
+    set(GRIDDYN_HAVE_MPI FALSE)
 endif(MPI_ENABLE)
 
-### just check some intenal options
-if (BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY)
-message(fatal "BOTH BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY cannot be specified together otherwise nothing works")
+# just check some intenal options
+if(BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY)
+    message(
+        fatal
+        "BOTH BUILD_DEBUG_ONLY AND BUILD_RELEASE_ONLY cannot be specified together otherwise nothing works"
+    )
 endif()
 
 # ------------------------------------------------------------
 # Find (and test) the KLU libraries
 # ------------------------------------------------------------
 
-option(DISABLE_KLU "disable KLU (not recommended [slow], turn on AUTOBUILD_KLU if your system doesn't have SuiteSparse installed)" OFF)
+option(
+    DISABLE_KLU
+    "disable KLU (not recommended [slow], turn on AUTOBUILD_KLU if your system doesn't have SuiteSparse installed)"
+    OFF
+)
 
 if(NOT DISABLE_KLU)
     include(addKLU_targets)
@@ -261,16 +370,14 @@ include(addSundials)
 set(optional_component_test_files)
 set(optional_system_test_files)
 
-set (optional_library_key_headers )
-set (optional_library_functions )
-
-
+set(optional_library_key_headers)
+set(optional_library_functions)
 
 # ------------------------------------------------------------
 # setting the RPATH
 # ------------------------------------------------------------
 # use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
 
 # when building, don't use the install RPATH already
 # (but later on when installing)
@@ -278,42 +385,59 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
 set(CMAKE_MACOSX_RPATH 1)
 
-set(CMAKE_BUILD_RPATH "${AUTOBUILD_INSTALL_PATH}/bin;${AUTOBUILD_INSTALL_PATH}/lib;${AUTOBUILD_INSTALL_PATH}/lib64")
+set(
+    CMAKE_BUILD_RPATH
+    "${AUTOBUILD_INSTALL_PATH}/bin;${AUTOBUILD_INSTALL_PATH}/lib;${AUTOBUILD_INSTALL_PATH}/lib64"
+)
 
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-
 # the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" isSystemDir)
+list(
+    FIND
+        CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" isSystemDir
+)
 if("${isSystemDir}" STREQUAL "-1")
-   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
 endif("${isSystemDir}" STREQUAL "-1")
 
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+list(
+    FIND
+        CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir
+)
 if("${isSystemDir}" STREQUAL "-1")
-    list(APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+    list(
+        APPEND
+            CMAKE_INSTALL_RPATH
+            "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+    )
 endif("${isSystemDir}" STREQUAL "-1")
 
-if (NOT Boost_USE_STATIC_LIBS)
-	list(APPEND CMAKE_INSTALL_RPATH ${Boost_LIBRARY_DIRS})
-	list(APPEND CMAKE_BUILD_RPATH ${Boost_LIBRARY_DIRS})
+if(NOT Boost_USE_STATIC_LIBS)
+    list(APPEND CMAKE_INSTALL_RPATH ${Boost_LIBRARY_DIRS})
+    list(APPEND CMAKE_BUILD_RPATH ${Boost_LIBRARY_DIRS})
 endif()
-
 
 # ------------------------------------------------------------
 # global include directories
 # ------------------------------------------------------------
-target_include_directories(griddyn_base INTERFACE
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-	$<BUILD_INTERFACE:${AUTOBUILD_INSTALL_PATH}/include>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+target_include_directories(
+    griddyn_base
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${AUTOBUILD_INSTALL_PATH}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_include_directories(griddyn_base SYSTEM INTERFACE
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty>
-	$<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
+target_include_directories(
+    griddyn_base SYSTEM
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty>
+        $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>
 )
 
 # ------------------------------------------------------------
@@ -323,7 +447,7 @@ target_include_directories(griddyn_base SYSTEM INTERFACE
 add_subdirectory(src/formatInterpreters)
 
 add_subdirectory(src/core)
-#required for utilities library
+# required for utilities library
 
 add_subdirectory(src/utilities)
 
@@ -339,14 +463,14 @@ add_library(griddyn_optional INTERFACE)
 
 option(ENABLE_PLUGINS "Enable support for plugin modules" OFF)
 
-if (ENABLE_PLUGINS)
-	if (BOOST_VERSION_LEVEL==0)
-		set(ENABLE_PLUGINS OFF)
-		message(WARNING "Plugin support requires BOOST 1.61 or higher")
-	else()
-		add_subdirectory(src/plugins)
-		set(DL_REQUIRED ON)
-	endif()
+if(ENABLE_PLUGINS)
+    if(BOOST_VERSION_LEVEL==0)
+        set(ENABLE_PLUGINS OFF)
+        message(WARNING "Plugin support requires BOOST 1.61 or higher")
+    else()
+        add_subdirectory(src/plugins)
+        set(DL_REQUIRED ON)
+    endif()
 endif(ENABLE_PLUGINS)
 
 # ------------------------------------------------------------
@@ -357,9 +481,9 @@ option(LOAD_EXTRA_MODELS "Compile and load extraModels" ON)
 # If extra models are used enabled try to locate the libraries
 # link against them.
 
-if (LOAD_EXTRA_MODELS)
-  add_subdirectory(src/extraModels)
-  target_link_libraries(griddyn_optional INTERFACE extraModelLibrary)
+if(LOAD_EXTRA_MODELS)
+    add_subdirectory(src/extraModels)
+    target_link_libraries(griddyn_optional INTERFACE extraModelLibrary)
 endif(LOAD_EXTRA_MODELS)
 
 # ------------------------------------------------------------
@@ -370,9 +494,9 @@ option(LOAD_EXTRA_SOLVERS "Compile and load extraSolvers" OFF)
 # If extra solvers are used enabled try to locate the libraries
 # link against them.
 
-if (LOAD_EXTRA_SOLVERS)
-  add_subdirectory(src/extraSolvers)
-  target_link_libraries(griddyn_optional INTERFACE extraSolverLibrary)
+if(LOAD_EXTRA_SOLVERS)
+    add_subdirectory(src/extraSolvers)
+    target_link_libraries(griddyn_optional INTERFACE extraSolverLibrary)
 endif(LOAD_EXTRA_SOLVERS)
 
 # ------------------------------------------------------------
@@ -381,18 +505,16 @@ endif(LOAD_EXTRA_SOLVERS)
 
 option(FMI_ENABLE "Enable FMI support" ON)
 
-
-if (FMI_ENABLE)
-	if (BOOST_VERSION_LEVEL==0)
-		set(FMI_ENABLE OFF CACHE BOOL "Enable FMI Support" FORCE)
-		message(WARNING "FMI support requires BOOST 1.61 or higher")
-	else()
-		add_subdirectory(src/fmi)
-		target_link_libraries(griddyn_optional PUBLIC INTERFACE fmiGDLibrary)
-		set(DL_REQUIRED ON)
-	endif()
+if(FMI_ENABLE)
+    if(BOOST_VERSION_LEVEL==0)
+        set(FMI_ENABLE OFF CACHE BOOL "Enable FMI Support" FORCE)
+        message(WARNING "FMI support requires BOOST 1.61 or higher")
+    else()
+        add_subdirectory(src/fmi)
+        target_link_libraries(griddyn_optional PUBLIC INTERFACE fmiGDLibrary)
+        set(DL_REQUIRED ON)
+    endif()
 endif(FMI_ENABLE)
-
 
 # ------------------------------------------------------------
 # FSKIT
@@ -401,9 +523,9 @@ endif(FMI_ENABLE)
 option(FSKIT_ENABLE "Enable FSKIT support" OFF)
 
 if(FSKIT_ENABLE)
-  set(GRIDDYN_HAVE_FSKIT 1)
-  add_subdirectory(src/fskit)
-  target_link_libraries(griddyn_optional INTERFACE fskitLibrary)
+    set(GRIDDYN_HAVE_FSKIT 1)
+    add_subdirectory(src/fskit)
+    target_link_libraries(griddyn_optional INTERFACE fskitLibrary)
 endif(FSKIT_ENABLE)
 
 # ------------------------------------------------------------
@@ -411,35 +533,49 @@ endif(FSKIT_ENABLE)
 # ------------------------------------------------------------
 
 if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-  option(ENABLE_64_BIT_INDEXING "set all indexing and count variables to 64 bit unsigned (Usually not required)" OFF)
+    option(
+        ENABLE_64_BIT_INDEXING
+        "set all indexing and count variables to 64 bit unsigned (Usually not required)"
+        OFF
+    )
 endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-
 
 # ------------------------------------------------------------
 # Enable message logging
 # ------------------------------------------------------------
-option(GRIDDYN_DISABLE_LOGGING "disable all normal, debug, and trace logging in GridDyn" OFF)
-if (NOT DISABLE_LOGGING)
-option(GRIDDYN_DISABLE_TRACE_LOGGING "disable trace logging" OFF)
-option(GRIDDYN_DISABLE_DEBUG_LOGGING "disable debug logging" OFF)
+option(
+    GRIDDYN_DISABLE_LOGGING
+    "disable all normal, debug, and trace logging in GridDyn" OFF
+)
+if(NOT DISABLE_LOGGING)
+    option(GRIDDYN_DISABLE_TRACE_LOGGING "disable trace logging" OFF)
+    option(GRIDDYN_DISABLE_DEBUG_LOGGING "disable debug logging" OFF)
 endif()
 
-option (GRIDDYN_GENERATE_DOXYGEN_DOC "Generate Doxygen doc target" OFF)
+option(GRIDDYN_GENERATE_DOXYGEN_DOC "Generate Doxygen doc target" OFF)
 
-if (GRIDDYN_GENERATE_DOXYGEN_DOC)
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
+if(GRIDDYN_GENERATE_DOXYGEN_DOC)
+    find_package(Doxygen)
+    if(DOXYGEN_FOUND)
 
-	SHOW_VARIABLE(DOXYGEN_OUTPUT_DIR PATH "location to put Doxygen docs" "${CMAKE_CURRENT_SOURCE_DIR}/docs")
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-	add_custom_target(doc
-	${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs}
-	COMMENT "Generating API documentation with Doxygen" VERBATIM
-)
-endif(DOXYGEN_FOUND)
-endif (GRIDDYN_GENERATE_DOXYGEN_DOC)
-
+        show_variable(
+            DOXYGEN_OUTPUT_DIR
+            PATH
+            "location to put Doxygen docs"
+            "${CMAKE_CURRENT_SOURCE_DIR}/docs"
+        )
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/config/Doxyfile.in
+            ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY
+        )
+        add_custom_target(
+            doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs}
+            COMMENT "Generating API documentation with Doxygen"
+            VERBATIM
+        )
+    endif(DOXYGEN_FOUND)
+endif(GRIDDYN_GENERATE_DOXYGEN_DOC)
 
 # ------------------------------------------------------------
 # Enable HELICS executable
@@ -448,65 +584,88 @@ endif (GRIDDYN_GENERATE_DOXYGEN_DOC)
 option(HELICS_EXECUTABLE "Enable the HELICS executable to be built" OFF)
 # If HELICS_EXECUTABLE is load the helics directory
 # link against them.  the variable is here since we would enable the zmq libraries with it on and that should be done
-#before actually including helics
+# before actually including helics
 
-if (HELICS_EXECUTABLE)
-	SHOW_VARIABLE(HELICS_INSTALL_PATH PATH "path to the helics installation" "${PROJECT_BINARY_DIR}/libs")
-	set(ZMQ_NEEDED ON CACHE BOOL "ZMQ is needed" FORCE)
+if(HELICS_EXECUTABLE)
+    show_variable(
+        HELICS_INSTALL_PATH
+        PATH
+        "path to the helics installation"
+        "${PROJECT_BINARY_DIR}/libs"
+    )
+    set(ZMQ_NEEDED ON CACHE BOOL "ZMQ is needed" FORCE)
 else(HELICS_EXECUTABLE)
-	HIDE_VARIABLE(HELICS_INSTALL_PATH)
+    hide_variable(HELICS_INSTALL_PATH)
 endif(HELICS_EXECUTABLE)
 
 # ------------------------------------------------------------
 # Enable ZMQ interfacing
 # ------------------------------------------------------------
 
-option(ENABLE_NETWORKING_LIBRARY "Enable network based communiation components" OFF)
+option(
+    ENABLE_NETWORKING_LIBRARY "Enable network based communiation components" OFF
+)
 
-cmake_dependent_option(DIME_ENABLE "Enable connection with Dime" OFF "ENABLE_NETWORKING_LIBRARY" OFF)
-cmake_dependent_option(TCP_ENABLE "Enable TCP connection library" ON "ENABLE_NETWORKING_LIBRARY" OFF)
-if (DIME_ENABLE)
-	set(ZMQ_NEEDED ON CACHE BOOL "ZMQ is needed" FORCE)
+cmake_dependent_option(
+    DIME_ENABLE
+    "Enable connection with Dime"
+    OFF
+    "ENABLE_NETWORKING_LIBRARY"
+    OFF
+)
+cmake_dependent_option(
+    TCP_ENABLE
+    "Enable TCP connection library"
+    ON
+    "ENABLE_NETWORKING_LIBRARY"
+    OFF
+)
+if(DIME_ENABLE)
+    set(ZMQ_NEEDED ON CACHE BOOL "ZMQ is needed" FORCE)
 endif(DIME_ENABLE)
 
-HIDE_VARIABLE(ZMQ_NEEDED)
+hide_variable(ZMQ_NEEDED)
 
-cmake_dependent_option(ZMQ_ENABLE "Enable ZMQ networking library" OFF "NOT ZMQ_NEEDED" OFF)
+cmake_dependent_option(
+    ZMQ_ENABLE
+    "Enable ZMQ networking library"
+    OFF
+    "NOT ZMQ_NEEDED"
+    OFF
+)
 
 # If ZMQ library is enabled try to locate it and link against it
 
-if ((ZMQ_ENABLE) OR (ZMQ_NEEDED))
-	include(addZeroMQ)
-	if (NOT ZeroMQ_FOUND)
-		message(SEND_ERROR "unable to locate zmq library")
-	endif()
+if((ZMQ_ENABLE) OR (ZMQ_NEEDED))
+    include(addZeroMQ)
+    if(NOT ZeroMQ_FOUND)
+        message(SEND_ERROR "unable to locate zmq library")
+    endif()
 endif()
 
-if (ENABLE_NETWORKING_LIBRARY)
-	add_subdirectory(src/networking)
-	target_link_libraries(griddyn_optional INTERFACE networking)
+if(ENABLE_NETWORKING_LIBRARY)
+    add_subdirectory(src/networking)
+    target_link_libraries(griddyn_optional INTERFACE networking)
 endif()
 
-if (HELICS_EXECUTABLE)
-	include(addHELICS)
-	add_subdirectory(src/helics)
-	target_link_libraries(griddyn_optional INTERFACE helicsLib)
+if(HELICS_EXECUTABLE)
+    include(addHELICS)
+    add_subdirectory(src/helics)
+    target_link_libraries(griddyn_optional INTERFACE helicsLib)
 endif(HELICS_EXECUTABLE)
 
-file(GLOB KEY_LIBRARY_FILES  ${PROJECT_BINARY_DIR}/libs/bin/*)
+file(GLOB KEY_LIBRARY_FILES ${PROJECT_BINARY_DIR}/libs/bin/*)
 message(STATUS "key files ${KEY_LIBRARY_FILES}")
 # ------------------------------------------------------------
 # load the subdirectories
 # ------------------------------------------------------------
 
-
-
 option(OPTIMIZATION_ENABLE "Enable Optimization libraries" OFF)
 # If OPTIMIZATION is enabled try to locate the libraries
 # link against them.
 if(OPTIMIZATION_ENABLE)
-	add_subdirectory(src/optimization)
-	target_link_libraries(griddyn_optional INTERFACE optimization)
+    add_subdirectory(src/optimization)
+    target_link_libraries(griddyn_optional INTERFACE optimization)
 endif(OPTIMIZATION_ENABLE)
 
 add_subdirectory(src/coupling)
@@ -518,27 +677,33 @@ add_subdirectory(src/fileInput)
 add_subdirectory(src/runner)
 
 if(BUILD_SHARED_FMI_LIBRARY)
-	add_subdirectory(src/fmi_export)
+    add_subdirectory(src/fmi_export)
 endif(BUILD_SHARED_FMI_LIBRARY)
 
 if(BUILD_SHARED_LIBS)
-	add_subdirectory(src/griddyn_shared)
+    add_subdirectory(src/griddyn_shared)
 endif(BUILD_SHARED_LIBS)
 
 add_subdirectory(src/gridDynMain)
 
-install(TARGETS griddyn_base griddyn_optional
-	EXPORT griddyn-targets
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	COMPONENT libraries)
+install(
+    TARGETS griddyn_base griddyn_optional
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 # ------------------------------------------------------------
 # Enable clang analysis and formatting tools
 # ------------------------------------------------------------
 
-option(ENABLE_CLANG_TOOLS "if clang is found enable some custom targets for clang formatting and tidy" OFF)
+option(
+    ENABLE_CLANG_TOOLS
+    "if clang is found enable some custom targets for clang formatting and tidy"
+    OFF
+)
 
-if (ENABLE_CLANG_TOOLS)
-include(clang-cxx-dev-tools)
+if(ENABLE_CLANG_TOOLS)
+    include(clang-cxx-dev-tools)
 endif(ENABLE_CLANG_TOOLS)
 # ------------------------------------------------------------
 # Enable testCore construction?
@@ -546,43 +711,54 @@ endif(ENABLE_CLANG_TOOLS)
 
 option(TEST_ENABLE "Enable unit testing construction" ON)
 
-if (TEST_ENABLE)
-	#message(STATUS "otcf:${optional_component_test_files}")
-	add_subdirectory(test)
-if(BUILD_SHARED_LIBS)
-	add_subdirectory(test/testSharedLibrary)
-endif(BUILD_SHARED_LIBS)
-	#enable_testing()
-	#add_test(NAME gridDynTest COMMAND testCore)
+if(TEST_ENABLE)
+    # message(STATUS "otcf:${optional_component_test_files}")
+    add_subdirectory(test)
+    if(BUILD_SHARED_LIBS)
+        add_subdirectory(test/testSharedLibrary)
+    endif(BUILD_SHARED_LIBS)
+    # enable_testing()
+    # add_test(NAME gridDynTest COMMAND testCore)
 endif(TEST_ENABLE)
 
-
-set(GRIDDYN_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "install path for GriddynConfig.cmake")
-
+set(
+    GRIDDYN_CMAKECONFIG_INSTALL_DIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    CACHE STRING "install path for GriddynConfig.cmake"
+)
 
 install(DIRECTORY examples/ DESTINATION examples COMPONENT examples)
-#file(GLOB ebraidfiles "examples/braid_examples/*.*")
-#install(FILES ${ebraidfiles} DESTINATION examples/braid_examples COMPONENT examples)
+# file(GLOB ebraidfiles "examples/braid_examples/*.*")
+# install(FILES ${ebraidfiles} DESTINATION examples/braid_examples COMPONENT examples)
 
 set(binfiles bin/configure.griddyn bin/pgriddyn bin/pgriddyn_debug)
-install(PROGRAMS ${binfiles} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
+install(
+    PROGRAMS ${binfiles}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT binaries
+)
 
-install(FILES ${KEY_LIBRARY_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
+install(
+    FILES ${KEY_LIBRARY_FILES}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT binaries
+)
 
-install (EXPORT griddyn-targets
-	NAMESPACE Griddyn::
-	DESTINATION ${GRIDDYN_CMAKECONFIG_INSTALL_DIR}
-	COMPONENT libs
-	)
+install(
+    EXPORT griddyn-targets
+    NAMESPACE Griddyn::
+    DESTINATION ${GRIDDYN_CMAKECONFIG_INSTALL_DIR}
+    COMPONENT libs
+)
 
 # ------------------------------------------------------------
 # Future Additions
 # ------------------------------------------------------------
 
-#adding dlls
+# adding dlls
 # install(FILES ${LOCATION_OF_FILES} DESTINATION bin)
-#file(GLOB docs "docs/manuals/*")
-#install(FILES ${docs} DESTINATION docs)
+# file(GLOB docs "docs/manuals/*")
+# install(FILES ${docs} DESTINATION docs)
 
 # ------------------------------------------------------------
 # CTest
@@ -592,29 +768,64 @@ if(TEST_ENABLE)
     include(CTest)
     find_program(CTEST_MEMORYCHECK_COMMAND valgrind)
 
-    add_test(NAME Example179BusDynamicTest COMMAND gridDynMain ${PROJECT_SOURCE_DIR}/test/test_files/IEEE_test_cases/ieee300.cdf)
-    set_property(TEST Example179BusDynamicTest PROPERTY LABELS Quick Continuous Nightly)
+    add_test(
+        NAME Example179BusDynamicTest
+        COMMAND
+            gridDynMain
+            ${PROJECT_SOURCE_DIR}/test/test_files/IEEE_test_cases/ieee300.cdf
+    )
+    set_property(
+        TEST Example179BusDynamicTest
+        PROPERTY
+            LABELS
+            Quick
+            Continuous
+            Nightly
+    )
 
     add_test(NAME testComponents COMMAND testComponents)
     add_test(NAME testLibrary COMMAND testLibrary)
     add_test(NAME testSystem COMMAND testSystem)
     add_test(NAME testExtra COMMAND testExtra)
-    set_property(TEST testComponents testLibrary testSystem PROPERTY LABELS Nightly Release)
+    set_property(
+        TEST testComponents testLibrary testSystem
+        PROPERTY LABELS Nightly Release
+    )
     set_property(TEST testExtra PROPERTY LABELS TESTLABEL Release)
 
     # Runs a subset of the overall tests
-    add_test(NAME testComponentsQuick COMMAND testComponents --run_test=@quick)
-    add_test(NAME testLibraryQuick COMMAND testLibrary --run_test=@quick)
-    add_test(NAME testSystemQuick COMMAND testSystem --run_test=@quick)
-    set_property(TEST testComponentsQuick testSystemQuick PROPERTY LABELS Quick Continuous)
-    set_property(TEST testLibraryQuick PROPERTY LABELS Quick Continuous Valgrind)
+    add_test(NAME testComponentsQuick COMMAND testComponents --RUN_TEST=@QUICK)
+    add_test(NAME testLibraryQuick COMMAND testLibrary --RUN_TEST=@QUICK)
+    add_test(NAME testSystemQuick COMMAND testSystem --RUN_TEST=@QUICK)
+    set_property(
+        TEST testComponentsQuick testSystemQuick
+        PROPERTY LABELS Quick Continuous
+    )
+    set_property(
+        TEST testLibraryQuick
+        PROPERTY
+            LABELS
+            Quick
+            Continuous
+            Valgrind
+    )
 
     if(BUILD_GRIDDYN_SHARED_LIBRARY)
         add_test(NAME testSharedLibrary COMMAND shared_library_tests)
         set_property(TEST testSharedLibrary PROPERTY LABELS Nightly Release)
 
-        add_test(NAME testSharedLibraryQuick COMMAND shared_library_tests --run_test=@quick)
-        set_property(TEST testSharedLibraryQuick PROPERTY LABELS Quick Continuous Valgrind)
+        add_test(
+            NAME testSharedLibraryQuick
+            COMMAND shared_library_tests --RUN_TEST=@QUICK
+        )
+        set_property(
+            TEST testSharedLibraryQuick
+            PROPERTY
+                LABELS
+                Quick
+                Continuous
+                Valgrind
+        )
     endif()
 endif()
 
@@ -622,71 +833,102 @@ endif()
 # swig interface builds
 # ------------------------------------------------------------
 
-if (INTERFACE_BUILD)
-	add_subdirectory(swig)
+if(INTERFACE_BUILD)
+    add_subdirectory(swig)
 endif()
-
-
 
 # ------------------------------------------------------------
 # CPack
 # ------------------------------------------------------------
-option(ENABLE_PACKAGE_BUILD "Add projects for making packages and installers for HELICS" OFF)
+option(
+    ENABLE_PACKAGE_BUILD
+    "Add projects for making packages and installers for HELICS" OFF
+)
 
 if(ENABLE_PACKAGE_BUILD)
-set(CPACK_PACKAGE_NAME "GridDyn")
-set(CPACK_PACKAGE_VENDOR "Lawrence Livermore National Security LLC")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GridDyn Installer")
-set(CPACK_PACKAGE_VERSION "${GRIDDYN_VERSION}")
-set(CPACK_PACKAGE_VERSION_MAJOR ${GRIDDYN_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${GRIDDYN_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${GRIDDYN_VERSION_PATCH})
+    set(CPACK_PACKAGE_NAME "GridDyn")
+    set(CPACK_PACKAGE_VENDOR "Lawrence Livermore National Security LLC")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GridDyn Installer")
+    set(CPACK_PACKAGE_VERSION "${GRIDDYN_VERSION}")
+    set(CPACK_PACKAGE_VERSION_MAJOR ${GRIDDYN_VERSION_MAJOR})
+    set(CPACK_PACKAGE_VERSION_MINOR ${GRIDDYN_VERSION_MINOR})
+    set(CPACK_PACKAGE_VERSION_PATCH ${GRIDDYN_VERSION_PATCH})
 
-set(CPACK_COMPONENTS_ALL applications headers libs binaries matlab python java octave examples)
+    set(
+        CPACK_COMPONENTS_ALL
+        applications
+        headers
+        libs
+        binaries
+        matlab
+        python
+        java
+        octave
+        examples
+    )
 
-if (WIN32)
-	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}\\\\LICENSE")
-else(WIN32)
-	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
-endif(WIN32)
+    if(WIN32)
+        set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}\\\\LICENSE")
+    else(WIN32)
+        set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+    endif(WIN32)
 
-set(CPACK_COMPONENT_APPLICATIONS_DISPLAY_NAME "Application")
- set(CPACK_COMPONENT_LIBS_DISPLAY_NAME "Libraries")
- set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Headers")
- set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Libraries")
- set(CPACK_COMPONENT_EXAMPLES_DISPLAY_NAME "Examples")
+    set(CPACK_COMPONENT_APPLICATIONS_DISPLAY_NAME "Application")
+    set(CPACK_COMPONENT_LIBS_DISPLAY_NAME "Libraries")
+    set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Headers")
+    set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Libraries")
+    set(CPACK_COMPONENT_EXAMPLES_DISPLAY_NAME "Examples")
 
- set(CPACK_COMPONENT_MATLAB_GROUP interfaces)
- set(CPACK_COMPONENT_JAVA_GROUP interfaces)
- set(CPACK_COMPONENT_OCTAVE_GROUP interfaces)
- set(CPACK_COMPONENT_PYTHON_GROUP interfaces)
+    set(CPACK_COMPONENT_MATLAB_GROUP interfaces)
+    set(CPACK_COMPONENT_JAVA_GROUP interfaces)
+    set(CPACK_COMPONENT_OCTAVE_GROUP interfaces)
+    set(CPACK_COMPONENT_PYTHON_GROUP interfaces)
 
- set(CPACK_COMPONENT_APPLICATION_DESCRIPTION "Executables and helper applications for GridDyn")
- set(CPACK_COMPONENT_LIBS_DESCRIPTION "Libraries for compiling and linking with GridDyn")
- set(CPACK_COMPONENT_HEADERS_DESCRIPTION "Headers for linking and compiling with GridDyn")
- set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for GrdDyn")
- set(CPACK_COMPONENT_EXAMPLES_DESCRIPTION "Example files for GridDyn")
+    set(
+        CPACK_COMPONENT_APPLICATION_DESCRIPTION
+        "Executables and helper applications for GridDyn"
+    )
+    set(
+        CPACK_COMPONENT_LIBS_DESCRIPTION
+        "Libraries for compiling and linking with GridDyn"
+    )
+    set(
+        CPACK_COMPONENT_HEADERS_DESCRIPTION
+        "Headers for linking and compiling with GridDyn"
+    )
+    set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for GrdDyn")
+    set(CPACK_COMPONENT_EXAMPLES_DESCRIPTION "Example files for GridDyn")
 
- set(CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION "additional language interfaces for GridDyn")
+    set(
+        CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION
+        "additional language interfaces for GridDyn"
+    )
 
- set(CPACK_COMPONENT_LIBS_DEPENDS headers)
- set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
- if (WIN32)
-	set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}\\\\docgen\\\\images\\\\griddyn.ico")
-	set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/docgen/images/griddyn.ico")
+    set(CPACK_COMPONENT_LIBS_DEPENDS headers)
+    set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
+    if(WIN32)
+        set(
+            CPACK_PACKAGE_ICON
+            "${CMAKE_SOURCE_DIR}\\\\docgen\\\\images\\\\griddyn.ico"
+        )
+        set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/docgen/images/griddyn.ico")
 
-	set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local\\\\")
-	set(CPACK_NSIS_URL_INFO_ABOUT "https://www.github.com/LLNL/GridDyn")
-	set(CPACK_NSIS_MENU_LINKS
-		"https://www.github.com/LLNL/GridDyn" "GridDyn source code"
-		"https://www.griddyn.org" "GridDyn Web Page")
+        set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local\\\\")
+        set(CPACK_NSIS_URL_INFO_ABOUT "https://www.github.com/LLNL/GridDyn")
+        set(
+            CPACK_NSIS_MENU_LINKS
+            "https://www.github.com/LLNL/GridDyn"
+            "GridDyn source code"
+            "https://www.griddyn.org"
+            "GridDyn Web Page"
+        )
 
-		set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local\\\\")
-else(WIN32)
-	set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/docgen/images/griddyn.ico")
-endif(WIN32)
-set(CPACK_SOURCE_IGNORE_FILES  "/Build*/;/build*/;/.git/")
+        set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local\\\\")
+    else(WIN32)
+        set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/docgen/images/griddyn.ico")
+    endif(WIN32)
+    set(CPACK_SOURCE_IGNORE_FILES "/Build*/;/build*/;/.git/")
 
-#THIS LINE MUST BE LAST
-include(CPack)
+    # THIS LINE MUST BE LAST
+    include(CPack)
 endif(ENABLE_PACKAGE_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,9 +794,9 @@ if(TEST_ENABLE)
     set_property(TEST testExtra PROPERTY LABELS TESTLABEL Release)
 
     # Runs a subset of the overall tests
-    add_test(NAME testComponentsQuick COMMAND testComponents --RUN_TEST=@QUICK)
-    add_test(NAME testLibraryQuick COMMAND testLibrary --RUN_TEST=@QUICK)
-    add_test(NAME testSystemQuick COMMAND testSystem --RUN_TEST=@QUICK)
+    add_test(NAME testComponentsQuick COMMAND testComponents --run_test=@quick)
+    add_test(NAME testLibraryQuick COMMAND testLibrary --run_test=@quick)
+    add_test(NAME testSystemQuick COMMAND testSystem --run_test=@quick)
     set_property(
         TEST testComponentsQuick testSystemQuick
         PROPERTY LABELS Quick Continuous
@@ -816,7 +816,7 @@ if(TEST_ENABLE)
 
         add_test(
             NAME testSharedLibraryQuick
-            COMMAND shared_library_tests --RUN_TEST=@QUICK
+            COMMAND shared_library_tests --run_test=@quick
         )
         set_property(
             TEST testSharedLibraryQuick

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,47 +8,49 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(coreObject_headers
+set(
+    coreObject_headers
     propertyBuffer.h
-	coreDefinitions.hpp
-	coreProperties.hpp
-	objectFactory.hpp
-	objectFactoryTemplates.hpp
-	factoryTemplates.hpp
-	coreExceptions.h
-	coreOwningPtr.hpp
-	helperObject.h
-	coreObject.h
-	nullObject.h
-	coreObjectList.h
-	coreObjectTemplates.hpp
-	objectOperatorInterface.hpp
-	objectInterpreter.h
+    coreDefinitions.hpp
+    coreProperties.hpp
+    objectFactory.hpp
+    objectFactoryTemplates.hpp
+    factoryTemplates.hpp
+    coreExceptions.h
+    coreOwningPtr.hpp
+    helperObject.h
+    coreObject.h
+    nullObject.h
+    coreObjectList.h
+    coreObjectTemplates.hpp
+    objectOperatorInterface.hpp
+    objectInterpreter.h
+)
 
-    )
+set(
+    coreObject_sources
+    objectFactory.cpp
+    coreObject.cpp
+    nullObject.cpp
+    coreObjectList.cpp
+    coreExceptions.cpp
+    helperObject.cpp
+    propertyBuffer.cpp
+    objectInterpreter.cpp
+)
 
-set(coreObject_sources
-	objectFactory.cpp
-	coreObject.cpp
-	nullObject.cpp
-	coreObjectList.cpp
-	coreExceptions.cpp
-	helperObject.cpp
-	propertyBuffer.cpp
-	objectInterpreter.cpp
-	)
+add_library(coreObjects STATIC ${coreObject_headers} ${coreObject_sources})
+set_target_properties(coreObjects PROPERTIES FOLDER libraries)
+target_link_libraries(coreObjects PUBLIC utilities)
+install(
+    TARGETS coreObjects
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-	add_library(coreObjects STATIC ${coreObject_headers} ${coreObject_sources})
-	set_target_properties (coreObjects PROPERTIES FOLDER libraries)
-	target_link_libraries(coreObjects PUBLIC utilities)
-	INSTALL(TARGETS coreObjects
-		EXPORT griddyn-targets
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}
-		COMPONENT libraries)
-
-
-INSTALL(FILES ${coreObject_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/core
-  COMPONENT headers)
-
-
+install(
+    FILES ${coreObject_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/core
+    COMPONENT headers
+)

--- a/src/coupling/CMakeLists.txt
+++ b/src/coupling/CMakeLists.txt
@@ -1,7 +1,7 @@
 # LLNS Copyright Start
 # Copyright (c) 2014-2018, Lawrence Livermore National Security
-# This work was performed under the auspices of the U.S. Department 
-# of Energy by Lawrence Livermore National Laboratory in part under 
+# This work was performed under the auspices of the U.S. Department
+# of Energy by Lawrence Livermore National Laboratory in part under
 # Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
 # Produced at the Lawrence Livermore National Laboratory.
 # All rights reserved.
@@ -9,27 +9,28 @@
 # LLNS Copyright End
 
 # set variable shared_sources with the sources for the coupling library
-set(coupling_sources
-    GhostSwingBusManager.cpp
-    )
+set(coupling_sources GhostSwingBusManager.cpp)
 
-set(coupling_headers
-    GhostSwingBusManager.h
-	GhostSwingBusMessageTypes.h
-    )
-if (GRIDDYN_HAVE_MPI)
-	list(APPEND coupling_sources MpiService.cpp)	
-	list(APPEND coupling_headers MpiService.h)
+set(coupling_headers GhostSwingBusManager.h GhostSwingBusMessageTypes.h)
+if(GRIDDYN_HAVE_MPI)
+    list(APPEND coupling_sources MpiService.cpp)
+    list(APPEND coupling_headers MpiService.h)
 endif(GRIDDYN_HAVE_MPI)
 # require MPI for this project
 
 add_library(coupling_static_lib STATIC ${coupling_sources} ${coupling_headers})
 
 target_link_libraries(coupling_static_lib PUBLIC griddyn_base)
-set_target_properties (coupling_static_lib PROPERTIES FOLDER libraries)
-INSTALL(TARGETS coupling_static_lib EXPORT griddyn-targets  DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+set_target_properties(coupling_static_lib PROPERTIES FOLDER libraries)
+install(
+    TARGETS coupling_static_lib
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${shared_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn COMPONENT headers)
-
-
-
+install(
+    FILES ${shared_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)

--- a/src/extraModels/CMakeLists.txt
+++ b/src/extraModels/CMakeLists.txt
@@ -8,31 +8,29 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(extra_sources
-	extraModels.cpp
-	txThermalModel.cpp
-	txLifeSpan.cpp
-	)
+set(extra_sources extraModels.cpp txThermalModel.cpp txLifeSpan.cpp)
 
-set(extra_headers
-	extraModels.h
-	txThermalModel.h
-	txLifeSpan.h
-	)
+set(extra_headers extraModels.h txThermalModel.h txLifeSpan.h)
 
 add_library(extraModelLibrary STATIC ${extra_sources} ${extra_headers})
-set_target_properties (extraModelLibrary PROPERTIES FOLDER libraries)
+set_target_properties(extraModelLibrary PROPERTIES FOLDER libraries)
 
 target_link_libraries(extraModelLibrary PUBLIC griddyn)
-INSTALL(TARGETS extraModelLibrary EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS extraModelLibrary
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${extra_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraModels
- COMPONENT headers)
+install(
+    FILES ${extra_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraModels
+    COMPONENT headers
+)
 
+list(APPEND optional_library_key_headers extraModels/extraModels.h)
+list(APPEND optional_library_functions loadExtraModels)
 
-list (APPEND optional_library_key_headers extraModels/extraModels.h)
-list (APPEND optional_library_functions loadExtraModels)
-
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)

--- a/src/extraSolvers/CMakeLists.txt
+++ b/src/extraSolvers/CMakeLists.txt
@@ -1,213 +1,250 @@
 # LLNS Copyright Start
 # Copyright (c) 2014-2018, Lawrence Livermore National Security
-# This work was performed under the auspices of the U.S. Department 
-# of Energy by Lawrence Livermore National Laboratory in part under 
+# This work was performed under the auspices of the U.S. Department
+# of Energy by Lawrence Livermore National Laboratory in part under
 # Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
 # Produced at the Lawrence Livermore National Laboratory.
 # All rights reserved.
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(extra_solver_sources
-	extraSolvers.cpp
-	)
-	
-set(extra_solver_headers
-	extraSolvers.h
-	)
+set(extra_solver_sources extraSolvers.cpp)
 
-set(paradae_headers
-   paradae/common/def.h
-   paradae/equations/AllEquations.h
-   paradae/equations/Equation.h
-   paradae/equations/Equation_DAE.h
-   paradae/equations/Equation_DAE_full.h
-   paradae/equations/Equation_ODE.h
-   paradae/equations/EqGridDyn.h
-   paradae/math/DBlockTriMatrix.h
-   paradae/math/DenseMatrix.h
-   paradae/math/IPoly.h
-   paradae/math/IVander.h
-   paradae/math/IVanderExt.h
-   paradae/math/PMultiVector.h
-   paradae/math/PVector.h
-   paradae/math/SBlockTriMatrix.h
-   paradae/math/SMultiVector.h
-   paradae/math/SVector.h
-   paradae/math/SparseMatrix.h
-   paradae/math/Vector.h
-   paradae/math/VirtualMatrix.h
-   paradae/math/VirtualVector.h
-   paradae/math/paradaeArrayData.h
-   paradae/problems/ODEProblem.h
-   paradae/solvers/LineSearch.h
-   paradae/solvers/Newton.h
-   paradae/solvers/NewtonStats.h
-   paradae/solvers/Solver.h
-   paradae/timeintegrators/AllTimeIntegrators.h
-   paradae/timeintegrators/BackwardDiff.h
-   paradae/timeintegrators/BackwardEuler.h
-   paradae/timeintegrators/Billington_23.h
-   paradae/timeintegrators/BogaSham_23.h
-   paradae/timeintegrators/Cash_24.h
-   paradae/timeintegrators/Cash_34.h
-   paradae/timeintegrators/DormPrince_45.h
-   paradae/timeintegrators/ExpMidPoint.h
-   paradae/timeintegrators/ExpTrapezoidal.h
-   paradae/timeintegrators/FE_ExpTrap_12.h
-   paradae/timeintegrators/ForwardEuler.h
-   paradae/timeintegrators/Fudziah_45.h
-   paradae/timeintegrators/Gauss4.h
-   paradae/timeintegrators/Gauss6.h
-   paradae/timeintegrators/ImpMidPoint.h
-   paradae/timeintegrators/ImpTrapezoidal.h
-   paradae/timeintegrators/ImpVarUnk_12.h
-   paradae/timeintegrators/Kutta3.h
-   paradae/timeintegrators/Kutta4.h
-   paradae/timeintegrators/Radau3.h
-   paradae/timeintegrators/Ralston.h
-   paradae/timeintegrators/RungeKutta.h
-   paradae/timeintegrators/RungeKutta_DIRK.h
-   paradae/timeintegrators/RungeKutta_Explicit.h
-   paradae/timeintegrators/RungeKutta_Implicit.h
-   paradae/timeintegrators/RungeKutta_SDIRK.h
-   paradae/timeintegrators/SDIRK_12.h
-   paradae/timeintegrators/TimeIntegrator.h
-   )
+set(extra_solver_headers extraSolvers.h)
 
-set(paradae_sources
-   paradae/common/def.cxx
-   paradae/equations/Equation.cxx
-   paradae/equations/Equation_ODE.cxx
-   paradae/equations/EqGridDyn.cxx
-   paradae/math/DBlockTriMatrix.cxx
-   paradae/math/DenseMatrix.cxx
-   paradae/math/IPoly.cxx
-   paradae/math/IVander.cxx
-   paradae/math/IVanderExt.cxx
-   paradae/math/PMultiVector.cxx
-   paradae/math/PVector.cxx
-   paradae/math/SBlockTriMatrix.cxx
-   paradae/math/SMultiVector.cxx
-   paradae/math/SVector.cxx
-   paradae/math/SparseMatrix.cxx
-   paradae/math/Vector.cxx
-   paradae/math/VirtualMatrix.cxx
-   paradae/math/paradaeArrayData.cxx
-   paradae/problems/ODEProblem.cxx
-   paradae/solvers/LineSearch.cxx
-   paradae/solvers/Newton.cxx
-   paradae/solvers/NewtonStats.cxx
-   paradae/solvers/Solver.cxx
-   paradae/timeintegrators/BackwardDiff.cxx
-   paradae/timeintegrators/BackwardEuler.cxx
-   paradae/timeintegrators/Billington_23.cxx
-   paradae/timeintegrators/BogaSham_23.cxx
-   paradae/timeintegrators/Cash_24.cxx
-   paradae/timeintegrators/Cash_34.cxx
-   paradae/timeintegrators/DormPrince_45.cxx
-   paradae/timeintegrators/ExpMidPoint.cxx
-   paradae/timeintegrators/ExpTrapezoidal.cxx
-   paradae/timeintegrators/FE_ExpTrap_12.cxx
-   paradae/timeintegrators/ForwardEuler.cxx
-   paradae/timeintegrators/Fudziah_45.cxx
-   paradae/timeintegrators/Gauss4.cxx
-   paradae/timeintegrators/Gauss6.cxx
-   paradae/timeintegrators/ImpMidPoint.cxx
-   paradae/timeintegrators/ImpTrapezoidal.cxx
-   paradae/timeintegrators/ImpVarUnk_12.cxx
-   paradae/timeintegrators/Kutta3.cxx
-   paradae/timeintegrators/Kutta4.cxx
-   paradae/timeintegrators/Radau3.cxx
-   paradae/timeintegrators/Ralston.cxx
-   paradae/timeintegrators/RungeKutta.cxx
-   paradae/timeintegrators/RungeKutta_DIRK.cxx
-   paradae/timeintegrators/RungeKutta_Explicit.cxx
-   paradae/timeintegrators/RungeKutta_Implicit.cxx
-   paradae/timeintegrators/RungeKutta_SDIRK.cxx
-   paradae/timeintegrators/SDIRK_12.cxx
-   paradae/timeintegrators/TimeIntegrator.cxx
-   )
-   
-OPTION(BUILD_BRAID_SOLVER "enable the braid parallel in time solver integration" OFF)
-OPTION(BUILD_SUPERLUMT_SOLVER "enable a superLU solver" OFF)
-OPTION(BUILD_PARADAE_SOLVERS "enable inclusion of PARADAE solvers" OFF)
+set(
+    paradae_headers
+    paradae/common/def.h
+    paradae/equations/AllEquations.h
+    paradae/equations/Equation.h
+    paradae/equations/Equation_DAE.h
+    paradae/equations/Equation_DAE_full.h
+    paradae/equations/Equation_ODE.h
+    paradae/equations/EqGridDyn.h
+    paradae/math/DBlockTriMatrix.h
+    paradae/math/DenseMatrix.h
+    paradae/math/IPoly.h
+    paradae/math/IVander.h
+    paradae/math/IVanderExt.h
+    paradae/math/PMultiVector.h
+    paradae/math/PVector.h
+    paradae/math/SBlockTriMatrix.h
+    paradae/math/SMultiVector.h
+    paradae/math/SVector.h
+    paradae/math/SparseMatrix.h
+    paradae/math/Vector.h
+    paradae/math/VirtualMatrix.h
+    paradae/math/VirtualVector.h
+    paradae/math/paradaeArrayData.h
+    paradae/problems/ODEProblem.h
+    paradae/solvers/LineSearch.h
+    paradae/solvers/Newton.h
+    paradae/solvers/NewtonStats.h
+    paradae/solvers/Solver.h
+    paradae/timeintegrators/AllTimeIntegrators.h
+    paradae/timeintegrators/BackwardDiff.h
+    paradae/timeintegrators/BackwardEuler.h
+    paradae/timeintegrators/Billington_23.h
+    paradae/timeintegrators/BogaSham_23.h
+    paradae/timeintegrators/Cash_24.h
+    paradae/timeintegrators/Cash_34.h
+    paradae/timeintegrators/DormPrince_45.h
+    paradae/timeintegrators/ExpMidPoint.h
+    paradae/timeintegrators/ExpTrapezoidal.h
+    paradae/timeintegrators/FE_ExpTrap_12.h
+    paradae/timeintegrators/ForwardEuler.h
+    paradae/timeintegrators/Fudziah_45.h
+    paradae/timeintegrators/Gauss4.h
+    paradae/timeintegrators/Gauss6.h
+    paradae/timeintegrators/ImpMidPoint.h
+    paradae/timeintegrators/ImpTrapezoidal.h
+    paradae/timeintegrators/ImpVarUnk_12.h
+    paradae/timeintegrators/Kutta3.h
+    paradae/timeintegrators/Kutta4.h
+    paradae/timeintegrators/Radau3.h
+    paradae/timeintegrators/Ralston.h
+    paradae/timeintegrators/RungeKutta.h
+    paradae/timeintegrators/RungeKutta_DIRK.h
+    paradae/timeintegrators/RungeKutta_Explicit.h
+    paradae/timeintegrators/RungeKutta_Implicit.h
+    paradae/timeintegrators/RungeKutta_SDIRK.h
+    paradae/timeintegrators/SDIRK_12.h
+    paradae/timeintegrators/TimeIntegrator.h
+)
 
-if (BUILD_BRAID_SOLVER)
-find_package(Braid)
-list(APPEND extra_solver_sources ${paradae_sources} braid/braidSolver.cpp braid/braid_driver.cxx)
-list(APPEND extra_solver_headers ${paradae_headers} braid/braidInterface.h braid/braid_driver.h)
-elseif (BUILD_PARADAE_SOLVERS)
-list(APPEND extra_solver_sources ${paradae_sources})
-list(APPEND extra_solver_headers ${paradae_headers})
+set(
+    paradae_sources
+    paradae/common/def.cxx
+    paradae/equations/Equation.cxx
+    paradae/equations/Equation_ODE.cxx
+    paradae/equations/EqGridDyn.cxx
+    paradae/math/DBlockTriMatrix.cxx
+    paradae/math/DenseMatrix.cxx
+    paradae/math/IPoly.cxx
+    paradae/math/IVander.cxx
+    paradae/math/IVanderExt.cxx
+    paradae/math/PMultiVector.cxx
+    paradae/math/PVector.cxx
+    paradae/math/SBlockTriMatrix.cxx
+    paradae/math/SMultiVector.cxx
+    paradae/math/SVector.cxx
+    paradae/math/SparseMatrix.cxx
+    paradae/math/Vector.cxx
+    paradae/math/VirtualMatrix.cxx
+    paradae/math/paradaeArrayData.cxx
+    paradae/problems/ODEProblem.cxx
+    paradae/solvers/LineSearch.cxx
+    paradae/solvers/Newton.cxx
+    paradae/solvers/NewtonStats.cxx
+    paradae/solvers/Solver.cxx
+    paradae/timeintegrators/BackwardDiff.cxx
+    paradae/timeintegrators/BackwardEuler.cxx
+    paradae/timeintegrators/Billington_23.cxx
+    paradae/timeintegrators/BogaSham_23.cxx
+    paradae/timeintegrators/Cash_24.cxx
+    paradae/timeintegrators/Cash_34.cxx
+    paradae/timeintegrators/DormPrince_45.cxx
+    paradae/timeintegrators/ExpMidPoint.cxx
+    paradae/timeintegrators/ExpTrapezoidal.cxx
+    paradae/timeintegrators/FE_ExpTrap_12.cxx
+    paradae/timeintegrators/ForwardEuler.cxx
+    paradae/timeintegrators/Fudziah_45.cxx
+    paradae/timeintegrators/Gauss4.cxx
+    paradae/timeintegrators/Gauss6.cxx
+    paradae/timeintegrators/ImpMidPoint.cxx
+    paradae/timeintegrators/ImpTrapezoidal.cxx
+    paradae/timeintegrators/ImpVarUnk_12.cxx
+    paradae/timeintegrators/Kutta3.cxx
+    paradae/timeintegrators/Kutta4.cxx
+    paradae/timeintegrators/Radau3.cxx
+    paradae/timeintegrators/Ralston.cxx
+    paradae/timeintegrators/RungeKutta.cxx
+    paradae/timeintegrators/RungeKutta_DIRK.cxx
+    paradae/timeintegrators/RungeKutta_Explicit.cxx
+    paradae/timeintegrators/RungeKutta_Implicit.cxx
+    paradae/timeintegrators/RungeKutta_SDIRK.cxx
+    paradae/timeintegrators/SDIRK_12.cxx
+    paradae/timeintegrators/TimeIntegrator.cxx
+)
+
+option(
+    BUILD_BRAID_SOLVER "enable the braid parallel in time solver integration"
+    OFF
+)
+option(BUILD_SUPERLUMT_SOLVER "enable a superLU solver" OFF)
+option(BUILD_PARADAE_SOLVERS "enable inclusion of PARADAE solvers" OFF)
+
+if(BUILD_BRAID_SOLVER)
+    find_package(Braid)
+    list(
+        APPEND
+            extra_solver_sources
+            ${paradae_sources}
+            braid/braidSolver.cpp
+            braid/braid_driver.cxx
+    )
+    list(
+        APPEND
+            extra_solver_headers
+            ${paradae_headers}
+            braid/braidInterface.h
+            braid/braid_driver.h
+    )
+elseif(BUILD_PARADAE_SOLVERS)
+    list(APPEND extra_solver_sources ${paradae_sources})
+    list(APPEND extra_solver_headers ${paradae_headers})
 endif()
 
-IF (GRIDDYN_HAVE_MPI)
-	list(APPEND extra_solver_sources 
-		paradae/common/MapParam.cxx
-		paradae/common/Timer.cxx
-		)
-	list(APPEND extra_solver_headers 
-		paradae/common/def_mpi.h
-		paradae/common/MapParam.h
-		paradae/common/Timer.h
-	)
-ELSEIF(BUILD_BRAID_SOLVER)
-	message(warning "Braid requires MPI to function")
-ENDIF()
+if(GRIDDYN_HAVE_MPI)
+    list(
+        APPEND
+            extra_solver_sources paradae/common/MapParam.cxx
+            paradae/common/Timer.cxx
+    )
+    list(
+        APPEND
+            extra_solver_headers
+            paradae/common/def_mpi.h
+            paradae/common/MapParam.h
+            paradae/common/Timer.h
+    )
+elseif(BUILD_BRAID_SOLVER)
+    message(WARNING "Braid requires MPI to function")
+endif()
 
 find_library(UMFPACK_LIBRARY umfpack HINTS ${SuiteSparse_DIRECT_LIBRARY_DIR})
 
+# find_package(LAPACKE)
+# if (LAPACKE_FOUND)
+# INCLUDE_DIRECTORIES(${LAPACKE_INCLUDE_DIRS})
+# endif()
 
-#find_package(LAPACKE)
-#if (LAPACKE_FOUND)
-#INCLUDE_DIRECTORIES(${LAPACKE_INCLUDE_DIRS})
-#endif()
+add_library(
+    extraSolverLibrary
+    STATIC
+    ${extra_solver_sources}
+    ${extra_solver_headers}
+)
+set_target_properties(extraSolverLibrary PROPERTIES FOLDER libraries)
 
-add_library(extraSolverLibrary STATIC ${extra_solver_sources} ${extra_solver_headers})
-set_target_properties (extraSolverLibrary PROPERTIES FOLDER libraries)
+if(WIN32)
 
-if (WIN32)
 else(WIN32)
-find_library(LAPACKE_LIBRARY lapacke HINTS /lib64 PATHS ${AUTOBUILD_INSTALL_PATH}/lib)
-target_link_libraries(extraSolverLibrary PUBLIC ${LAPACKE_LIBRARY})
-INCLUDE_DIRECTORIES(/usr/include/lapacke)
+    find_library(
+        LAPACKE_LIBRARY lapacke
+        HINTS /lib64
+        PATHS ${AUTOBUILD_INSTALL_PATH}/lib
+    )
+    target_link_libraries(extraSolverLibrary PUBLIC ${LAPACKE_LIBRARY})
+    include_directories(/usr/include/lapacke)
 endif(WIN32)
 
 target_link_libraries(extraSolverLibrary PUBLIC griddyn)
 target_link_libraries(extraSolverLibrary PUBLIC ${LAPACKE_LIBRARIES})
 target_link_libraries(extraSolverLibrary PUBLIC SuiteSparse::umfpack)
 
-if (BUILD_PARADAE_SOLVERS OR BUILD_BRAID_SOLVER)
-#source_group("paradae" FILES ${paradae_sources} ${paradae_headers})
-source_group("paradae\\timeIntegrators" REGULAR_EXPRESSION "paradae/timeintegrators/.*")
-source_group("paradae\\math" REGULAR_EXPRESSION "paradae/math/.*")
-source_group("paradae\\common" REGULAR_EXPRESSION "paradae/common/.*")
-source_group("paradae\\solvers" REGULAR_EXPRESSION "paradae/solvers/.*")
-source_group("paradae\\equations" REGULAR_EXPRESSION "paradae/equations/.*")
+if(BUILD_PARADAE_SOLVERS OR BUILD_BRAID_SOLVER)
+    # source_group("paradae" FILES ${paradae_sources} ${paradae_headers})
+    source_group(
+        "paradae\\timeIntegrators" REGULAR_EXPRESSION
+        "paradae/timeintegrators/.*"
+    )
+    source_group("paradae\\math" REGULAR_EXPRESSION "paradae/math/.*")
+    source_group("paradae\\common" REGULAR_EXPRESSION "paradae/common/.*")
+    source_group("paradae\\solvers" REGULAR_EXPRESSION "paradae/solvers/.*")
+    source_group("paradae\\equations" REGULAR_EXPRESSION "paradae/equations/.*")
 endif()
 
-if (BUILD_BRAID_SOLVER)
-target_link_libraries(extraSolverLibrary PUBLIC braid::braid)
-source_group("braid" REGULAR_EXPRESSION "braid/.*")
-target_compile_definitions(extraSolverLibrary PUBLIC "-DENABLE_BRAID")
+if(BUILD_BRAID_SOLVER)
+    target_link_libraries(extraSolverLibrary PUBLIC braid::braid)
+    source_group("braid" REGULAR_EXPRESSION "braid/.*")
+    target_compile_definitions(extraSolverLibrary PUBLIC "-DENABLE_BRAID")
 endif()
 
-IF (GRIDDYN_HAVE_MPI)
-	target_link_libraries(extraSolverLibrary PUBLIC MPI::MPI_C)
-ENDIF(GRIDDYN_HAVE_MPI)
+if(GRIDDYN_HAVE_MPI)
+    target_link_libraries(extraSolverLibrary PUBLIC MPI::MPI_C)
+endif(GRIDDYN_HAVE_MPI)
 
-target_include_directories(extraSolverLibrary PRIVATE ${SuiteSparse_DIRECT_INCLUDE_DIR})
+target_include_directories(
+    extraSolverLibrary
+    PRIVATE ${SuiteSparse_DIRECT_INCLUDE_DIR}
+)
 
-INSTALL(TARGETS extraSolverLibrary EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS extraSolverLibrary
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${extra_solver_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
- COMPONENT headers)
+install(
+    FILES ${extra_solver_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
+    COMPONENT headers
+)
 
+list(APPEND optional_library_key_headers extraSolvers/extraSolvers.h)
+list(APPEND optional_library_functions loadExtraSolvers)
 
-list (APPEND optional_library_key_headers extraSolvers/extraSolvers.h)
-list (APPEND optional_library_functions loadExtraSolvers)
-
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)

--- a/src/fileInput/CMakeLists.txt
+++ b/src/fileInput/CMakeLists.txt
@@ -8,82 +8,92 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#project name gridDynInout
+# project name gridDynInout
 
-set (reader_sources
-	stringInterpret.cpp
-	readerHelper.cpp
-	fileInput.cpp
-	gridParameter.cpp
-	readerInfo.cpp
-	)
+set(
+    reader_sources
+    stringInterpret.cpp
+    readerHelper.cpp
+    fileInput.cpp
+    gridParameter.cpp
+    readerInfo.cpp
+)
 
-set(elementReader_sources
-	readElementHelperFunctions.cpp
-	readBusElement.cpp
-	readEventElement.cpp
-	readLinkElement.cpp
-	readCollectorElement.cpp
-	readEconElement.cpp
-	readLibraryElement.cpp
-	readAreaElement.cpp
-	readArrayElement.cpp
-	readConditionElement.cpp
-	readRelayElement.cpp
-	readSolverElement.cpp
-	readSimulationElement.cpp
-	loadSubObjectsElement.cpp
-	readElementFile.cpp
-	objectLoadFromElementHelperFunctions.cpp
-	objectLoadHelperFunctions.cpp
-	)
+set(
+    elementReader_sources
+    readElementHelperFunctions.cpp
+    readBusElement.cpp
+    readEventElement.cpp
+    readLinkElement.cpp
+    readCollectorElement.cpp
+    readEconElement.cpp
+    readLibraryElement.cpp
+    readAreaElement.cpp
+    readArrayElement.cpp
+    readConditionElement.cpp
+    readRelayElement.cpp
+    readSolverElement.cpp
+    readSimulationElement.cpp
+    loadSubObjectsElement.cpp
+    readElementFile.cpp
+    objectLoadFromElementHelperFunctions.cpp
+    objectLoadHelperFunctions.cpp
+)
 
-set(formattedfileInput_sources
-	gridDynReadCDF.cpp
-	gridDynReadRAW.cpp
-	gridDynReadDYR.cpp
-	gridDynReadPSP.cpp
-	gridDynReadPTI.cpp
-	gridReadEPC.cpp
-	gridReadMatPower.cpp
-	gridReadPSAT.cpp
-	readMatDyn.cpp
-	gridDynReadCSV.cpp
-	readMatlabData.cpp
-	loadGDZ.cpp
-	readXMLfile.cpp
-	)
+set(
+    formattedfileInput_sources
+    gridDynReadCDF.cpp
+    gridDynReadRAW.cpp
+    gridDynReadDYR.cpp
+    gridDynReadPSP.cpp
+    gridDynReadPTI.cpp
+    gridReadEPC.cpp
+    gridReadMatPower.cpp
+    gridReadPSAT.cpp
+    readMatDyn.cpp
+    gridDynReadCSV.cpp
+    readMatlabData.cpp
+    loadGDZ.cpp
+    readXMLfile.cpp
+)
 
-set(fileInput_headers
-	readElement.h
-	readerHelper.h
-	fileInput.h
-	elementReaderTemplates.hpp
-	readerInfo.h
-	gridParameter.h
-	readElementFile.h
-	)
+set(
+    fileInput_headers
+    readElement.h
+    readerHelper.h
+    fileInput.h
+    elementReaderTemplates.hpp
+    readerInfo.h
+    gridParameter.h
+    readElementFile.h
+)
 
-
-set (fileInput_sources
-	${xml_sources}
-	${reader_sources}
-	${elementReader_sources}
-	${formattedfileInput_sources}
-	${fileInput_headers}
-	)
+set(
+    fileInput_sources
+    ${xml_sources}
+    ${reader_sources}
+    ${elementReader_sources}
+    ${formattedfileInput_sources}
+    ${fileInput_headers}
+)
 add_library(fileInput STATIC ${fileInput_sources})
 
 target_link_libraries(fileInput PUBLIC gridDynLoader formatInterpreter)
-source_group("Elements"  FILES  ${elementReader_sources})
-source_group("formatSpecific"  FILES  ${formattedfileInput_sources})
+source_group("Elements" FILES ${elementReader_sources})
+source_group("formatSpecific" FILES ${formattedfileInput_sources})
 source_group("general" FILES ${reader_sources})
 
-set_target_properties (fileInput PROPERTIES FOLDER libraries)
+set_target_properties(fileInput PROPERTIES FOLDER libraries)
 
-INSTALL(TARGETS fileInput EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS fileInput
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${fileInput_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fileInput
-  COMPONENT headers)
-
+install(
+    FILES ${fileInput_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fileInput
+    COMPONENT headers
+)

--- a/src/fmi/CMakeLists.txt
+++ b/src/fmi/CMakeLists.txt
@@ -8,84 +8,100 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(fmiImport_sources
-	fmi_import/fmiImport.cpp
-	fmi_import/fmiInfo.cpp
-	fmi_import/fmi2Object.cpp
-	fmi_import/fmi2ModelExchangeObject.cpp
-	fmi_import/fmi2CoSimObject.cpp
-	fmi_import/fmiVariableSet.cpp
-	fmi_import/fmiEnumDefinitions.cpp
-	fmi_import/fmiLibraryManager.cpp
+set(
+    fmiImport_sources
+    fmi_import/fmiImport.cpp
+    fmi_import/fmiInfo.cpp
+    fmi_import/fmi2Object.cpp
+    fmi_import/fmi2ModelExchangeObject.cpp
+    fmi_import/fmi2CoSimObject.cpp
+    fmi_import/fmiVariableSet.cpp
+    fmi_import/fmiEnumDefinitions.cpp
+    fmi_import/fmiLibraryManager.cpp
+)
 
-	)
+set(
+    fmiGD_sources
+    fmiGDinfo.cpp
+    fmi_models/fmiMESubModel.cpp
+    fmi_models/fmiCoSimSubModel.cpp
+    fmi_models/fmiMELoad.cpp
+    fmi_models/fmiCoSimLoad.cpp
+    fmi_models/fmiMELoad3phase.cpp
+    fmi_models/fmiCoSimLoad3phase.cpp
+    fmi_models/fmiExciter.cpp
+    fmi_models/outputEstimator.cpp
+    fmi_models/fmiGovernor.cpp
+    fmi_models/fmiGenModel.cpp
+    fmi_models/CymeDistLoad.cpp
+)
 
-set(fmiGD_sources
-	fmiGDinfo.cpp
-	fmi_models/fmiMESubModel.cpp
-	fmi_models/fmiCoSimSubModel.cpp
-	fmi_models/fmiMELoad.cpp
-	fmi_models/fmiCoSimLoad.cpp
-	fmi_models/fmiMELoad3phase.cpp
-	fmi_models/fmiCoSimLoad3phase.cpp
-	fmi_models/fmiExciter.cpp
-	fmi_models/outputEstimator.cpp
-	fmi_models/fmiGovernor.cpp
-	fmi_models/fmiGenModel.cpp
-	fmi_models/CymeDistLoad.cpp
-	)
+set(
+    fmiGD_headers
+    fmi_models/fmiMESubModel.h
+    fmi_models/fmiCoSimSubModel.h
+    fmi_models/fmiMELoad.h
+    fmi_models/fmiCoSimLoad.h
+    fmi_models/fmiMELoad3phase.h
+    fmi_models/fmiCoSimLoad3phase.h
+    fmi_models/fmiExciter.h
+    fmi_models/fmiGovernor.h
+    fmi_models/fmiGenModel.h
+    fmi_models/outputEstimator.h
+    fmi_models/fmiSupport.h
+    fmi_models/fmiMEWrapper.hpp
+    fmi_models/fmiCoSimWrapper.hpp
+    fmi_models/fmiWrapper.hpp
+    fmi_models/CymeDistLoad.h
+    fmiGDinfo.h
+)
+set(
+    fmiImport_headers
+    fmi_import/fmiInfo.h
+    fmi_import/fmiImport.h
+    fmi_import/fmiObjects.h
+    fmi_import/fmiEnumDefinitions.h
+    fmi_import/fmiLibraryManager.h
+)
 
-set(fmiGD_headers
-	fmi_models/fmiMESubModel.h
-	fmi_models/fmiCoSimSubModel.h
-	fmi_models/fmiMELoad.h
-	fmi_models/fmiCoSimLoad.h
-	fmi_models/fmiMELoad3phase.h
-	fmi_models/fmiCoSimLoad3phase.h
-	fmi_models/fmiExciter.h
-	fmi_models/fmiGovernor.h
-	fmi_models/fmiGenModel.h
-	fmi_models/outputEstimator.h
-	fmi_models/fmiSupport.h
-	fmi_models/fmiMEWrapper.hpp
-	fmi_models/fmiCoSimWrapper.hpp
-	fmi_models/fmiWrapper.hpp
-	fmi_models/CymeDistLoad.h
-	fmiGDinfo.h
-	)
-set(fmiImport_headers
-	fmi_import/fmiInfo.h
-	fmi_import/fmiImport.h
-	fmi_import/fmiObjects.h
-	fmi_import/fmiEnumDefinitions.h
-	fmi_import/fmiLibraryManager.h
-	)
-
-add_library(fmiGDLibrary STATIC ${fmiGD_sources} ${fmiImport_sources} ${fmiImport_headers} ${fmiGD_headers})
+add_library(
+    fmiGDLibrary
+    STATIC
+    ${fmiGD_sources}
+    ${fmiImport_sources}
+    ${fmiImport_headers}
+    ${fmiGD_headers}
+)
 
 source_group("gridDynFMU" FILES ${fmiGD_sources} ${fmiGD_headers})
 source_group("FMUImport" FILES ${fmiImport_sources} ${fmiImport_headers})
 
-set_target_properties (fmiGDLibrary PROPERTIES FOLDER fmi)
+set_target_properties(fmiGDLibrary PROPERTIES FOLDER fmi)
 
 target_link_libraries(fmiGDLibrary griddyn formatInterpreter)
 
-INSTALL(TARGETS fmiGDLibrary
-		EXPORT griddyn-targets
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}
-		COMPONENT libraries)
+install(
+    TARGETS fmiGDLibrary
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
+list(APPEND optional_library_key_headers fmi/fmiGDinfo.h)
+list(APPEND optional_library_functions loadFmiLibrary)
 
-list (APPEND optional_library_key_headers fmi/fmiGDinfo.h)
-list (APPEND optional_library_functions loadFmiLibrary)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)
 
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
+list(
+    APPEND
+        optional_component_test_files
+        ${PROJECT_SOURCE_DIR}/test/componentTests/testFMI.cpp
+)
+set(optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
 
-
-list(APPEND optional_component_test_files ${PROJECT_SOURCE_DIR}/test/componentTests/testFMI.cpp)
-set (optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
-
-INSTALL(FILES ${fmiImport_headers} ${fmiGD_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
-  COMPONENT headers)
+install(
+    FILES ${fmiImport_headers} ${fmiGD_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)

--- a/src/fmi_export/CMakeLists.txt
+++ b/src/fmi_export/CMakeLists.txt
@@ -8,106 +8,166 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-
-set(fmiShared_headers
-fmiRunner.h
-fmiCoordinator.h
-fmiCollector.h
-fmiEvent.h
-loadFMIExportObjects.h
+set(
+    fmiShared_headers
+    fmiRunner.h
+    fmiCoordinator.h
+    fmiCollector.h
+    fmiEvent.h
+    loadFMIExportObjects.h
 )
 
-set(fmiShared_sources
-fmiGridDynExport.cpp
-fmiRunner.cpp
-fmiCoordinator.cpp
-fmiCollector.cpp
-fmiEvent.cpp
-loadFMIExportObjects.cpp
+set(
+    fmiShared_sources
+    fmiGridDynExport.cpp
+    fmiRunner.cpp
+    fmiCoordinator.cpp
+    fmiCollector.cpp
+    fmiEvent.cpp
+    loadFMIExportObjects.cpp
 )
 
-set(fmiBuilder_headers
-fmiCoordinator.h
-fmiCollector.h
-fmiEvent.h
-loadFMIExportObjects.h
-fmuBuilder.h
-fmiRunner.h
+set(
+    fmiBuilder_headers
+    fmiCoordinator.h
+    fmiCollector.h
+    fmiEvent.h
+    loadFMIExportObjects.h
+    fmuBuilder.h
+    fmiRunner.h
 )
 
-set(fmiBuilder_sources
-fmiCoordinator.cpp
-fmiCollector.cpp
-fmiEvent.cpp
-loadFMIExportObjects.cpp
-fmuBuilder.cpp
-fmiRunner.cpp
-fmiGridDynExport.cpp
-
+set(
+    fmiBuilder_sources
+    fmiCoordinator.cpp
+    fmiCollector.cpp
+    fmiEvent.cpp
+    loadFMIExportObjects.cpp
+    fmuBuilder.cpp
+    fmiRunner.cpp
+    fmiGridDynExport.cpp
 )
 
-add_library(fmiGridDynSharedLib SHARED ${fmiShared_sources} ${fmiShared_headers})
+add_library(
+    fmiGridDynSharedLib
+    SHARED
+    ${fmiShared_sources}
+    ${fmiShared_headers}
+)
 
-set_target_properties(fmiGridDynSharedLib PROPERTIES CXX_VISIBILITY_PRESET hidden C_VISIBILITY_PRESET hidden)
+set_target_properties(
+    fmiGridDynSharedLib
+    PROPERTIES
+        CXX_VISIBILITY_PRESET
+        hidden
+        C_VISIBILITY_PRESET
+        hidden
+)
 
-set_target_properties (fmiGridDynSharedLib PROPERTIES FOLDER fmi)
+set_target_properties(fmiGridDynSharedLib PROPERTIES FOLDER fmi)
 
 add_library(fmiBuilder STATIC ${fmiBuilder_sources} ${fmiBuilder_headers})
 
 target_link_libraries(fmiBuilder PUBLIC runner)
 
-set_target_properties (fmiBuilder PROPERTIES FOLDER fmi)
-
+set_target_properties(fmiBuilder PROPERTIES FOLDER fmi)
 
 target_link_libraries(fmiGridDynSharedLib PRIVATE runner)
 
 set(GRIDDYNFMILIBRARY_BINARY_LOC ${CMAKE_CURRENT_BINARY_DIR})
 
-INSTALL(TARGETS fmiGridDynSharedLib EXPORT griddyn-targets
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(
+    TARGETS fmiGridDynSharedLib
+    EXPORT griddyn-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
 # Todo when minimum CMake version becomes 3.6: re-add EXCLUDE_FROM_ALL to these two install FILES commands for fmiGridDynSharedLib
-INSTALL(FILES $<TARGET_FILE:fmiGridDynSharedLib> DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
-INSTALL(FILES $<TARGET_LINKER_FILE:fmiGridDynSharedLib> DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-IF (WIN32)
-	if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/win64/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE win64)
-	else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/win32/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE win32)
-	endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-ELSE(WIN32)
- IF(UNIX)
-   if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/linux64/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE linux64 )
-	else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/linux32/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE linux32 )
-	endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-	ELSE(UNIX)
-	if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/darwin64/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE darwin64 )
-	else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-		INSTALL(TARGETS fmiGridDynSharedLib RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/darwin32/ COMPONENT runtime)
-		set(FMILIBRARY_TYPE darwin32 )
-	endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-	ENDIF(UNIX)
-ENDIF(WIN32)
+install(
+    FILES $<TARGET_FILE:fmiGridDynSharedLib>
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT
+    RUNTIME
+)
+install(
+    FILES $<TARGET_LINKER_FILE:fmiGridDynSharedLib>
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
+if(WIN32)
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+        install(
+            TARGETS fmiGridDynSharedLib
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/win64/ COMPONENT
+            RUNTIME
+        )
+        set(FMILIBRARY_TYPE win64)
+    else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+        install(
+            TARGETS fmiGridDynSharedLib
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/win32/ COMPONENT
+            RUNTIME
+        )
+        set(FMILIBRARY_TYPE win32)
+    endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+else(WIN32)
+    if(UNIX)
+        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            install(
+                TARGETS fmiGridDynSharedLib
+                LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/linux64/ COMPONENT
+                RUNTIME
+            )
+            set(FMILIBRARY_TYPE linux64)
+        else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            install(
+                TARGETS fmiGridDynSharedLib
+                LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/linux32/ COMPONENT
+                RUNTIME
+            )
+            set(FMILIBRARY_TYPE linux32)
+        endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    else(UNIX)
+        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            install(
+                TARGETS fmiGridDynSharedLib
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/darwin64/ COMPONENT
+                RUNTIME
+            )
+            set(FMILIBRARY_TYPE darwin64)
+        else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            install(
+                TARGETS fmiGridDynSharedLib
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/darwin32/ COMPONENT
+                RUNTIME
+            )
+            set(FMILIBRARY_TYPE darwin32)
+        endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    endif(UNIX)
+endif(WIN32)
 
-target_compile_definitions(fmiBuilder PRIVATE -DGRIDDYNFMILIBRARY_BINARY_LOC="${GRIDDYNFMILIBRARY_BINARY_LOC}")
-target_compile_definitions(fmiBuilder PRIVATE -DFMILIBRARY_TYPE="${FMILIBRARY_TYPE}")
+target_compile_definitions(
+    fmiBuilder PRIVATE
+    -DGRIDDYNFMILIBRARY_BINARY_LOC="${GRIDDYNFMILIBRARY_BINARY_LOC}"
+)
+target_compile_definitions(
+    fmiBuilder PRIVATE -DFMILIBRARY_TYPE="${FMILIBRARY_TYPE}"
+)
 
-list(APPEND optional_component_test_files ${CMAKE_CURRENT_SOURCE_DIR}/testFMIExport.cpp)
-set (optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
+list(
+    APPEND
+        optional_component_test_files
+        ${CMAKE_CURRENT_SOURCE_DIR}/testFMIExport.cpp
+)
+set(optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
 
 list(APPEND executable_only_components fmiBuilder)
 set(executable_only_components ${executable_only_components} PARENT_SCOPE)
 
-INSTALL(FILES ${fmiBuilder_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fmi_export
-  COMPONENT headers)
+install(
+    FILES ${fmiBuilder_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fmi_export
+    COMPONENT headers
+)

--- a/src/fncs/CMakeLists.txt
+++ b/src/fncs/CMakeLists.txt
@@ -11,98 +11,113 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(griddynFNCS_sources
-	gridDynFNCS.cpp
-	fncsSource.cpp
-	fncsCollector.cpp
-	fncsGhostBus.cpp
-	fncsLoad.cpp
-	fncsLibrary.cpp
-	fncsSupport.cpp
-	test/fncsTest.cpp
-	)
+set(
+    griddynFNCS_sources
+    gridDynFNCS.cpp
+    fncsSource.cpp
+    fncsCollector.cpp
+    fncsGhostBus.cpp
+    fncsLoad.cpp
+    fncsLibrary.cpp
+    fncsSupport.cpp
+    test/fncsTest.cpp
+)
 
-set(griddynFNCS_headers
-	fncsLibrary.h
-	fncsSource.h
-	fncsCollector.h
-	fncsGhostBus.h
-	fncsLoad.h
-	fncsSupport.h
-	test/fncsTest.h
-	)
+set(
+    griddynFNCS_headers
+    fncsLibrary.h
+    fncsSource.h
+    fncsCollector.h
+    fncsGhostBus.h
+    fncsLoad.h
+    fncsSupport.h
+    test/fncsTest.h
+)
 
-IF(USE_DUMMY_FNCS)
-	list(APPEND griddynFNCS_headers stub/fncs.hpp)
-	list (APPEND griddynFNCS_sources stub/fncs.cpp)
-ELSE(USE_DUMMY_FNCS)
-	list(APPEND griddynFNCS_headers fncslib/fncs.hpp)
-	list (APPEND griddynFNCS_sources fncslib/fncs.cpp)
-	list(APPEND griddynFNCS_headers fncslib/log.hpp)
-	list(APPEND griddynFNCS_headers fncslib/fncs_internal.hpp)
-	list (APPEND griddynFNCS_headers fncslib/fncs.h)
-ENDIF(USE_DUMMY_FNCS)
+if(USE_DUMMY_FNCS)
+    list(APPEND griddynFNCS_headers stub/fncs.hpp)
+    list(APPEND griddynFNCS_sources stub/fncs.cpp)
+else(USE_DUMMY_FNCS)
+    list(APPEND griddynFNCS_headers fncslib/fncs.hpp)
+    list(APPEND griddynFNCS_sources fncslib/fncs.cpp)
+    list(APPEND griddynFNCS_headers fncslib/log.hpp)
+    list(APPEND griddynFNCS_headers fncslib/fncs_internal.hpp)
+    list(APPEND griddynFNCS_headers fncslib/fncs.h)
+endif(USE_DUMMY_FNCS)
 
 link_directories(${external_link_directories})
 
 add_executable(griddynFNCS ${griddynFNCS_sources} ${griddynFNCS_headers})
 target_include_directories(griddynFNCS SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 
-INCLUDE_DIRECTORIES(.)
+include_directories(.)
 
-INCLUDE_DIRECTORIES(${formatInterpreter_include_directories})
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/griddyn)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/gridDynFileInput)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/utilities)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/gridDynCombined)
+include_directories(${formatInterpreter_include_directories})
+include_directories(${PROJECT_SOURCE_DIR}/src/griddyn)
+include_directories(${PROJECT_SOURCE_DIR}/src/gridDynFileInput)
+include_directories(${PROJECT_SOURCE_DIR}/src/utilities)
+include_directories(${PROJECT_SOURCE_DIR}/src/gridDynCombined)
 
-IF(USE_DUMMY_FNCS)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/fncs/stub)
-ADD_DEFINITIONS(-DUSE_DUMMY_FNCS )
-ELSE (USE_DUMMY_FNCS)
+if(USE_DUMMY_FNCS)
+    include_directories(${PROJECT_SOURCE_DIR}/src/fncs/stub)
+    add_definitions(-DUSE_DUMMY_FNCS)
+else(USE_DUMMY_FNCS)
 
-IF (USE_FNCS_SHARED_LIBRARY)
-INCLUDE_DIRECTORIES(${FNCS_INCLUDE_DIR})
-ELSE (USE_FNCS_SHARED_LIBRARY)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/fncs/fncslib)
-INCLUDE_DIRECTORIES(${CZMQ_INCLUDE_DIR})
-INCLUDE_DIRECTORIES(${ZMQ_INCLUDE_DIR})
-ENDIF(USE_FNCS_SHARED_LIBRARY)
+    if(USE_FNCS_SHARED_LIBRARY)
+        include_directories(${FNCS_INCLUDE_DIR})
+    else(USE_FNCS_SHARED_LIBRARY)
+        include_directories(${PROJECT_SOURCE_DIR}/src/fncs/fncslib)
+        include_directories(${CZMQ_INCLUDE_DIR})
+        include_directories(${ZMQ_INCLUDE_DIR})
+    endif(USE_FNCS_SHARED_LIBRARY)
 
-ENDIF(USE_DUMMY_FNCS)
+endif(USE_DUMMY_FNCS)
 
-FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test test_dir)
+file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test test_dir)
 
-IF(WIN32)
-#there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
-# to get the regex to work and I need two for visual studio to actually print it.
-# thus to it looks like this to replace '\' with '\\'
-#this will probably fail on macs yet
+if(WIN32)
+    # there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
+    # to get the regex to work and I need two for visual studio to actually print it.
+    # thus to it looks like this to replace '\' with '\\'
+    # this will probably fail on macs yet
 
-STRING(REGEX REPLACE "\\\\" "\\\\\\\\" test_dir ${test_dir})
-ENDIF(WIN32)
-#message(${test_dir})
+    string(
+        REGEX
+        REPLACE
+            "\\\\"
+            "\\\\\\\\"
+            test_dir
+            ${test_dir}
+    )
+endif(WIN32)
+# message(${test_dir})
 
-ADD_DEFINITIONS(-DFNCS_TEST_DIRECTORY="${test_dir}" )
+add_definitions(-DFNCS_TEST_DIRECTORY="${test_dir}")
 
 target_link_libraries(griddynFNCS gridDynCombined)
-IF(USE_DUMMY_FNCS)
+if(USE_DUMMY_FNCS)
 
+else(USE_DUMMY_FNCS)
+    if(USE_FNCS_SHARED_LIBRARY)
+        target_link_libraries(griddynFNCS ${FNCS_LIBRARIES})
+    else(USE_FNCS_SHARED_LIBRARY)
+        add_definitions(-DLIBFNCS_STATIC)
+    endif(USE_FNCS_SHARED_LIBRARY)
 
-ELSE(USE_DUMMY_FNCS)
-IF (USE_FNCS_SHARED_LIBRARY)
-target_link_libraries(griddynFNCS ${FNCS_LIBRARIES})
-ELSE (USE_FNCS_SHARED_LIBRARY)
-ADD_DEFINITIONS(-DLIBFNCS_STATIC)
-ENDIF(USE_FNCS_SHARED_LIBRARY)
-
-ENDIF(USE_DUMMY_FNCS)
+endif(USE_DUMMY_FNCS)
 
 foreach(keyfile IN LISTS KEY_LIBRARY_FILES)
-add_custom_command(TARGET griddynFNCS POST_BUILD        # Adds a post-build event to griddynFNCS
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-        "${keyfile}"      # <--this is in-file
-        $<TARGET_FILE_DIR:griddynFNCS>)                 # <--this is out-file path
+    add_custom_command(
+        TARGET
+        griddynFNCS
+        POST_BUILD # Adds a post-build event to griddynFNCS
+        COMMAND
+            ${CMAKE_COMMAND}
+            -E
+            copy_if_different # which executes "cmake - E copy_if_different..."
+            "${keyfile}" # <--this is in-file
+            $<TARGET_FILE_DIR:griddynFNCS>
+    ) # <--this is out-file path
 endforeach(keyfile)
 
-INSTALL(TARGETS griddynFNCS RUNTIME DESTINATION bin)
+install(TARGETS griddynFNCS RUNTIME DESTINATION bin)

--- a/src/formatInterpreters/CMakeLists.txt
+++ b/src/formatInterpreters/CMakeLists.txt
@@ -38,9 +38,9 @@ ${PROJECT_SOURCE_DIR}/ThirdParty/json/jsoncpp.cpp
 
 
 
-###########################################
+# ------------------------------------------------------------
 # building yaml
-#########################################
+# ------------------------------------------------------------
 OPTION(ENABLE_YAML "enable yaml file support in GridDyn" OFF)
 if (ENABLE_YAML)
 	include(buildYAML)
@@ -71,9 +71,9 @@ set(YAML_FOUND ${YAML_FOUND} PARENT_SCOPE)
 
 set(ZLIB_ROOT_DIR ${PROJECT_BINARY_DIR}/libs)
 
-###########################################
+# ------------------------------------------------------------
 # building ticpp and tinyxml2
-###########################################
+# ------------------------------------------------------------
 
 file(GLOB ticppfiles ${PROJECT_SOURCE_DIR}/ThirdParty/ticpp/*.cpp)
 file(GLOB ticpp_headers ${PROJECT_SOURCE_DIR}/ThirdParty/ticpp/*.h)
@@ -108,6 +108,3 @@ INSTALL(TARGETS formatInterpreter tinyxml EXPORT griddyn-targets DESTINATION ${C
 INSTALL(FILES ${elementReader_headers}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
   COMPONENT headers)
-
-
-

--- a/src/formatInterpreters/CMakeLists.txt
+++ b/src/formatInterpreters/CMakeLists.txt
@@ -8,64 +8,63 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#project name
+# project name
 
-set (elementReader_headers
-jsonReaderElement.h
-jsonElement.h
-tinyxml2ReaderElement.h
-tinyxmlReaderElement.h
-readerElement.h
-tomlElement.h
-tomlReaderElement.h
-iniReaderElement.h
+set(
+    elementReader_headers
+    jsonReaderElement.h
+    jsonElement.h
+    tinyxml2ReaderElement.h
+    tinyxmlReaderElement.h
+    readerElement.h
+    tomlElement.h
+    tomlReaderElement.h
+    iniReaderElement.h
 )
 
-set (elementReader_files
-jsonReaderElement.cpp
-jsonElement.cpp
-tinyxml2ReaderElement.cpp
-tinyxmlReaderElement.cpp
-readerElement.cpp
-tomlElement.cpp
-tomlReaderElement.cpp
-iniReaderElement.cpp
-${PROJECT_SOURCE_DIR}/ThirdParty/json/jsoncpp.cpp
+set(
+    elementReader_files
+    jsonReaderElement.cpp
+    jsonElement.cpp
+    tinyxml2ReaderElement.cpp
+    tinyxmlReaderElement.cpp
+    readerElement.cpp
+    tomlElement.cpp
+    tomlReaderElement.cpp
+    iniReaderElement.cpp
+    ${PROJECT_SOURCE_DIR}/ThirdParty/json/jsoncpp.cpp
 )
 
-#SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/config)
-
-
-
+# SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/config)
 
 # ------------------------------------------------------------
 # building yaml
 # ------------------------------------------------------------
-OPTION(ENABLE_YAML "enable yaml file support in GridDyn" OFF)
-if (ENABLE_YAML)
-	include(buildYAML)
-	set(YAML_ROOT_DIR ${AUTOBUILD_INSTALL_PATH})
+option(ENABLE_YAML "enable yaml file support in GridDyn" OFF)
+if(ENABLE_YAML)
+    include(buildYAML)
+    set(YAML_ROOT_DIR ${AUTOBUILD_INSTALL_PATH})
 
-	if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/yaml-cpp-targets.cmake)
-		build_yaml()
-	endif()
-	include(${AUTOBUILD_INSTALL_PATH}/cmake/yaml-cpp-targets.cmake)
+    if(NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/yaml-cpp-targets.cmake)
+        build_yaml()
+    endif()
+    include(${AUTOBUILD_INSTALL_PATH}/cmake/yaml-cpp-targets.cmake)
 
 endif(ENABLE_YAML)
 
-if (YAML_FOUND)
-	list(APPEND elementReader_files
-	yamlReaderElement.cpp
-	yamlElement.cpp)
+if(YAML_FOUND)
+    list(APPEND elementReader_files yamlReaderElement.cpp yamlElement.cpp)
 
-	list(APPEND elementReader_headers
-	yamlReaderElement.h
-	yamlElement.h)
+    list(APPEND elementReader_headers yamlReaderElement.h yamlElement.h)
 
-	list(APPEND optional_library_test_files ${PROJECT_SOURCE_DIR}/src/formatInterpreters/test/testYamlReader.cpp)
-	set (optional_library_test_files ${optional_library_test_files} PARENT_SCOPE)
+    list(
+        APPEND
+            optional_library_test_files
+            ${PROJECT_SOURCE_DIR}/src/formatInterpreters/test/testYamlReader.cpp
+    )
+    set(optional_library_test_files ${optional_library_test_files} PARENT_SCOPE)
 
-ENDIF(YAML_FOUND)
+endif(YAML_FOUND)
 
 set(YAML_FOUND ${YAML_FOUND} PARENT_SCOPE)
 
@@ -78,33 +77,48 @@ set(ZLIB_ROOT_DIR ${PROJECT_BINARY_DIR}/libs)
 file(GLOB ticppfiles ${PROJECT_SOURCE_DIR}/ThirdParty/ticpp/*.cpp)
 file(GLOB ticpp_headers ${PROJECT_SOURCE_DIR}/ThirdParty/ticpp/*.h)
 
-add_library(tinyxml STATIC ${ticppfiles} ${ticpp_headers}
-	${PROJECT_SOURCE_DIR}/ThirdParty/tinyxml2/tinyxml2.cpp
-	${PROJECT_SOURCE_DIR}/ThirdParty/tinyxml2/tinyxml2.h)
+add_library(
+    tinyxml
+    STATIC
+    ${ticppfiles}
+    ${ticpp_headers}
+    ${PROJECT_SOURCE_DIR}/ThirdParty/tinyxml2/tinyxml2.cpp
+    ${PROJECT_SOURCE_DIR}/ThirdParty/tinyxml2/tinyxml2.h
+)
 
 target_link_libraries(tinyxml griddyn_base)
 target_compile_definitions(tinyxml PUBLIC -DTIXML_USE_TICPP)
 
-IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	target_compile_options(tinyxml PRIVATE -Wno-suggest-override)
-ENDIF ()
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(tinyxml PRIVATE -Wno-suggest-override)
+endif()
 
-set_target_properties (tinyxml PROPERTIES FOLDER libraries)
+set_target_properties(tinyxml PROPERTIES FOLDER libraries)
 
-add_library(formatInterpreter STATIC ${elementReader_files} ${elementReader_headers} )
+add_library(
+    formatInterpreter
+    STATIC
+    ${elementReader_files}
+    ${elementReader_headers}
+)
 target_link_libraries(formatInterpreter PUBLIC tinyxml utilities)
 
-set_target_properties (formatInterpreter PROPERTIES FOLDER libraries)
+set_target_properties(formatInterpreter PROPERTIES FOLDER libraries)
 
+if(YAML_FOUND)
+    target_link_libraries(formatInterpreter PUBLIC yaml-cpp)
 
+endif(YAML_FOUND)
 
-IF (YAML_FOUND)
-target_link_libraries(formatInterpreter PUBLIC yaml-cpp)
+install(
+    TARGETS formatInterpreter tinyxml
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-ENDIF(YAML_FOUND)
-
-INSTALL(TARGETS formatInterpreter tinyxml EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-
-INSTALL(FILES ${elementReader_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
-  COMPONENT headers)
+install(
+    FILES ${elementReader_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)

--- a/src/fskit/CMakeLists.txt
+++ b/src/fskit/CMakeLists.txt
@@ -8,43 +8,61 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(fskit_sources
-  fskitCommunicator.cpp
-  gridDynFederatedScheduler.cpp
-  gridDynfskit.cpp
-  zonalRelayLogicalProcess.cpp
-  fskitRunner.cpp
-  GridDynFederatedSimulator.cpp
+set(
+    fskit_sources
+    fskitCommunicator.cpp
+    gridDynFederatedScheduler.cpp
+    gridDynfskit.cpp
+    zonalRelayLogicalProcess.cpp
+    fskitRunner.cpp
+    GridDynFederatedSimulator.cpp
 )
 
-set (fskit_headers
-	fskitCommunicator.h
-	gridDynFederatedScheduler.h
-	gridDynfskit.h
-	zonalRelayLogicalProcess.h
-	fskitRunner.h
-	GridDynFederatedSimulator.h
-	griddyn-tracer.h
+set(
+    fskit_headers
+    fskitCommunicator.h
+    gridDynFederatedScheduler.h
+    gridDynfskit.h
+    zonalRelayLogicalProcess.h
+    fskitRunner.h
+    GridDynFederatedSimulator.h
+    griddyn-tracer.h
 )
 
 find_package(FSKIT)
 
 add_library(fskitLibrary STATIC ${fskit_sources} ${fskit_headers})
 
-find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS mpi serialization REQUIRED)
+find_package(
+    Boost ${BOOST_MINIMUM_VERSION}
+    COMPONENTS mpi serialization REQUIRED
+)
 
 target_include_directories(fskitLibrary SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 target_include_directories(fskitLibrary PUBLIC ${FSKIT_INCLUDE_DIR})
-target_link_libraries(fskitLibrary runner ${FSKIT_LIBRARIES} ${Boost_SERIALIZATION_LIBRARY} ${Boost_MPI_LIBRARY})
+target_link_libraries(
+    fskitLibrary
+    runner
+    ${FSKIT_LIBRARIES}
+    ${Boost_SERIALIZATION_LIBRARY}
+    ${Boost_MPI_LIBRARY}
+)
 
-INSTALL(TARGETS fskitLibrary EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS fskitLibrary
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${fskit_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fskit
-  COMPONENT headers)
+install(
+    FILES ${fskit_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/fskit
+    COMPONENT headers
+)
 
-list (APPEND optional_library_key_headers fskit/gridDynfskit.h)
-list (APPEND optional_library_functions loadFskit)
+list(APPEND optional_library_key_headers fskit/gridDynfskit.h)
+list(APPEND optional_library_functions loadFskit)
 
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)

--- a/src/gridDynLoader/CMakeLists.txt
+++ b/src/gridDynLoader/CMakeLists.txt
@@ -8,72 +8,92 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-
-#build the file that loads the optional libraries
+# build the file that loads the optional libraries
 file(REMOVE_RECURSE ${PROJECT_BINARY_DIR}/libraryLoader.cpp)
 
-file(WRITE ${PROJECT_BINARY_DIR}/libraryLoader.cpp
-"/*LLNS Copyright Start\n"
-" *Copyright (c) 2014-2018, Lawrence Livermore National Security\n"
-" *This work was performed under the auspices of the U.S. Department\n"
-" *of Energy by Lawrence Livermore National Laboratory in part under\n"
-" *Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.\n"
-" *Produced at the Lawrence Livermore National Laboratory.\n"
-" *All rights reserved.\n"
-" *For details, see the LICENSE file.\n"
-" *LLNS Copyright End\n"
-" */\n"
-"\n"
-"//automatically generated file\n"
-"\#include \"gridDynLoader/libraryLoader.h\"\n"
-"\#include \"griddyn/griddyn-config.h\"\n"
+file(
+    WRITE
+        ${PROJECT_BINARY_DIR}/libraryLoader.cpp
+        "/*LLNS Copyright Start\n"
+        " *Copyright (c) 2014-2018, Lawrence Livermore National Security\n"
+        " *This work was performed under the auspices of the U.S. Department\n"
+        " *of Energy by Lawrence Livermore National Laboratory in part under\n"
+        " *Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.\n"
+        " *Produced at the Lawrence Livermore National Laboratory.\n"
+        " *All rights reserved.\n"
+        " *For details, see the LICENSE file.\n"
+        " *LLNS Copyright End\n"
+        " */\n"
+        "\n"
+        "//automatically generated file\n"
+        "\#include \"gridDynLoader/libraryLoader.h\"\n"
+        "\#include \"griddyn/griddyn-config.h\"\n"
 )
 
-
-foreach( header ${optional_library_key_headers})
-file(APPEND ${PROJECT_BINARY_DIR}/libraryLoader.cpp
-"\n"
-"\#include \"${header}\"\n")
+foreach(header ${optional_library_key_headers})
+    file(
+        APPEND
+            ${PROJECT_BINARY_DIR}/libraryLoader.cpp "\n"
+            "\#include \"${header}\"\n"
+    )
 endforeach(header)
 
-file(APPEND ${PROJECT_BINARY_DIR}/libraryLoader.cpp
-"namespace griddyn {\n"
-"void loadLibraries()\n"
-"{\n"
+file(
+    APPEND
+        ${PROJECT_BINARY_DIR}/libraryLoader.cpp
+        "namespace griddyn {\n"
+        "void loadLibraries()\n"
+        "{\n"
 )
 
-foreach( ns ${optional_library_functions})
-file(APPEND ${PROJECT_BINARY_DIR}/libraryLoader.cpp
-"\n"
-"${ns}();\n"
-"\n")
+foreach(ns ${optional_library_functions})
+    file(
+        APPEND
+            ${PROJECT_BINARY_DIR}/libraryLoader.cpp
+            "\n"
+            "${ns}();\n"
+            "\n"
+    )
 endforeach(ns)
 
-file(APPEND ${PROJECT_BINARY_DIR}/libraryLoader.cpp
-"\n"
-"}\n"
-"}//namespace griddyn")
+file(
+    APPEND
+        ${PROJECT_BINARY_DIR}/libraryLoader.cpp
+        "\n"
+        "}\n"
+        "}//namespace griddyn"
+)
 
-add_library(gridDynLoader STATIC libraryLoader.h ${PROJECT_BINARY_DIR}/libraryLoader.cpp)
+add_library(
+    gridDynLoader
+    STATIC
+    libraryLoader.h
+    ${PROJECT_BINARY_DIR}/libraryLoader.cpp
+)
 
-set_target_properties (gridDynLoader PROPERTIES FOLDER libraries)
+set_target_properties(gridDynLoader PROPERTIES FOLDER libraries)
 
-#message("optlibs: ${griddyn_optional_libraries}")
-#message("optheaders: ${griddyn_optional_include_dirs}")
-#message("external_libraries: ${external_library_list}")
-#message("external_lib_dirs: ${external_link_directories}")
+# message("optlibs: ${griddyn_optional_libraries}")
+# message("optheaders: ${griddyn_optional_include_dirs}")
+# message("external_libraries: ${external_library_list}")
+# message("external_lib_dirs: ${external_link_directories}")
 
-
-#fileInput needs to come first since it can depend on some of the optional libraries which in turn depend on the gridDyn Libraries and the external libraries
+# fileInput needs to come first since it can depend on some of the optional libraries which in turn depend on the gridDyn Libraries and the external libraries
 target_link_libraries(gridDynLoader griddyn_optional)
 
 if(DL_REQUIRED OR FMI_ENABLE)
-	target_link_libraries(gridDynLoader ${CMAKE_DL_LIBS})
+    target_link_libraries(gridDynLoader ${CMAKE_DL_LIBS})
 endif(DL_REQUIRED OR FMI_ENABLE)
 
-INSTALL(TARGETS gridDynLoader EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS gridDynLoader
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES libraryLoader.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
-   COMPONENT headers)
-
+install(
+    FILES libraryLoader.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)

--- a/src/gridDynMain/CMakeLists.txt
+++ b/src/gridDynMain/CMakeLists.txt
@@ -8,12 +8,9 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(gridDynMain_sources
-	gridDynMain.cpp
-	)
+set(gridDynMain_sources gridDynMain.cpp)
 
-set(gridDynMain_headers
-	)
+set(gridDynMain_headers)
 
 add_executable(gridDynMain ${gridDynMain_sources} ${gridDynMain_headers})
 
@@ -28,10 +25,21 @@ if(DIME_ENABLE)
 endif(DIME_ENABLE)
 
 foreach(keyfile IN LISTS KEY_LIBRARY_FILES)
-add_custom_command(TARGET gridDynMain POST_BUILD        # Adds a post-build event to gridDynMain
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-        "${keyfile}"      # <--this is in-file
-        $<TARGET_FILE_DIR:gridDynMain>)                 # <--this is out-file path
+    add_custom_command(
+        TARGET
+        gridDynMain
+        POST_BUILD # Adds a post-build event to gridDynMain
+        COMMAND
+            ${CMAKE_COMMAND}
+            -E
+            copy_if_different # which executes "cmake - E copy_if_different..."
+            "${keyfile}" # <--this is in-file
+            $<TARGET_FILE_DIR:gridDynMain>
+    ) # <--this is out-file path
 endforeach(keyfile)
 
-INSTALL(TARGETS gridDynMain RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
+install(
+    TARGETS gridDynMain
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT
+    RUNTIME
+)

--- a/src/gridDynServer/CMakeLists.txt
+++ b/src/gridDynServer/CMakeLists.txt
@@ -8,33 +8,26 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(griddynServer_sources
-	gridDynServerMain.cpp
-	gridDynServer.cpp
-	)
+set(griddynServer_sources gridDynServerMain.cpp gridDynServer.cpp)
 
-set(griddynServer_headers
-	gridDynServer.h
-	)
+set(griddynServer_headers gridDynServer.h)
 
 link_directories(${external_link_directories})
-
 
 set(GRIDYNSERVER_BINARY_LOC ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 
 add_executable(griddynServer ${griddynServer_sources} ${griddynServer_headers})
 target_include_directories(griddynServer SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 
-INCLUDE_DIRECTORIES(.)
+include_directories(.)
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/formatInterpreter)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/griddyn)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/gridDynFileInput)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/utilities)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/coupling)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/gridDynCombined)
+include_directories(${PROJECT_SOURCE_DIR}/src/formatInterpreter)
+include_directories(${PROJECT_SOURCE_DIR}/src/griddyn)
+include_directories(${PROJECT_SOURCE_DIR}/src/gridDynFileInput)
+include_directories(${PROJECT_SOURCE_DIR}/src/utilities)
+include_directories(${PROJECT_SOURCE_DIR}/src/coupling)
+include_directories(${PROJECT_SOURCE_DIR}/src/gridDynCombined)
 
+target_link_libraries(griddynServer gridDynCombined)
 
-target_link_libraries(griddynServer gridDynCombined )
-
-INSTALL(TARGETS griddynServer RUNTIME DESTINATION bin)
+install(TARGETS griddynServer RUNTIME DESTINATION bin)

--- a/src/griddyn/CMakeLists.txt
+++ b/src/griddyn/CMakeLists.txt
@@ -8,522 +8,559 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#project  GriddDyn
+# project  GriddDyn
 
-set(genmodel_headers
+set(
+    genmodel_headers
     GenModel.h
-	genmodels/GenModelClassical.h
-	genmodels/GenModel3.h
-	genmodels/GenModel4.h
-	genmodels/GenModel5.h
-	genmodels/GenModel5type2.h
-	genmodels/GenModel5type3.h
-	genmodels/GenModel6.h
-	genmodels/GenModel6type2.h
-	genmodels/GenModelGENROU.h
-	genmodels/GenModel8.h
-	genmodels/GenModelInverter.h
-	genmodels/otherGenModels.h
-	)
-
-set(genmodel_sources
-	${genmodel_headers}
-	genmodels/GenModel.cpp
-	genmodels/GenModelClassical.cpp
-	genmodels/GenModel3.cpp
-	genmodels/GenModel4.cpp
-	genmodels/GenModel5.cpp
-	genmodels/GenModel5type2.cpp
-	genmodels/GenModel5type3.cpp
-	genmodels/GenModel6.cpp
-	genmodels/GenModel6type2.cpp
-	genmodels/GenModelGENROU.cpp
-	genmodels/GenModel8.cpp
-	genmodels/GenModelInverter.cpp
-	)
-
-set(generator_headers
-	Generator.h
-	generators/variableGenerator.h
-	generators/isocController.h
-	generators/DynamicGenerator.h
-	)
-
-set (generator_sources
-	${generator_headers}
-	generators/Generator.cpp
-	generators/variableGenerator.cpp
-	generators/isocController.cpp
-	generators/DynamicGenerator.cpp
-	)
-
-set(gridSource_headers
-	Source.h
-	sources/sourceTypes.h
-	sources/rampSource.h
-	sources/fileSource.h
-	sources/randomSource.h
-	sources/pulseSource.h
-	sources/sineSource.h
-	sources/functionSource.h
-	sources/commSource.h
-	sources/blockSource.h
-	sources/grabberSource.h
+    genmodels/GenModelClassical.h
+    genmodels/GenModel3.h
+    genmodels/GenModel4.h
+    genmodels/GenModel5.h
+    genmodels/GenModel5type2.h
+    genmodels/GenModel5type3.h
+    genmodels/GenModel6.h
+    genmodels/GenModel6type2.h
+    genmodels/GenModelGENROU.h
+    genmodels/GenModel8.h
+    genmodels/GenModelInverter.h
+    genmodels/otherGenModels.h
 )
 
-set(gridSource_sources
-	${gridSource_headers}
-	sources/Source.cpp
-	sources/rampSource.cpp
-	sources/fileSource.cpp
-	sources/randomSource.cpp
-	sources/pulseSource.cpp
-	sources/sineSource.cpp
-	sources/functionSource.cpp
-	sources/commSource.cpp
-	sources/blockSource.cpp
-	sources/grabberSource.cpp
-	)
-
-set(exciter_headers
-	Exciter.h
-	Stabilizer.h
-	exciters/ExciterDC1A.h
-	exciters/ExciterDC2A.h
-	exciters/ExciterIEEEtype1.h
-	exciters/ExciterIEEEtype2.h
+set(
+    genmodel_sources
+    ${genmodel_headers}
+    genmodels/GenModel.cpp
+    genmodels/GenModelClassical.cpp
+    genmodels/GenModel3.cpp
+    genmodels/GenModel4.cpp
+    genmodels/GenModel5.cpp
+    genmodels/GenModel5type2.cpp
+    genmodels/GenModel5type3.cpp
+    genmodels/GenModel6.cpp
+    genmodels/GenModel6type2.cpp
+    genmodels/GenModelGENROU.cpp
+    genmodels/GenModel8.cpp
+    genmodels/GenModelInverter.cpp
 )
 
-set(exciter_sources
-	${exciter_headers}
-	exciters/Exciter.cpp
-	exciters/ExciterDC1A.cpp
-	exciters/ExciterDC2A.cpp
-	exciters/ExciterIEEEtype1.cpp
-	exciters/ExciterIEEEtype2.cpp
-	stabilizers/Stabilizer.cpp
-	)
-
-set(gov_headers
-	Governor.h
-	governors/GovernorTypes.h
-	governors/GovernorHydro.h
-	governors/GovernorIeeeSimple.h
-	governors/GovernorReheat.h
-	governors/GovernorSteamNR.h
-	governors/GovernorSteamTCSR.h
-	governors/GovernorTgov1.h
+set(
+    generator_headers
+    Generator.h
+    generators/variableGenerator.h
+    generators/isocController.h
+    generators/DynamicGenerator.h
 )
 
-set(gov_sources
-	${gov_headers}
-	governors/Governor.cpp
-	governors/GovernorHydro.cpp
-	governors/GovernorIeeeSimple.cpp
-	governors/GovernorReheat.cpp
-	governors/GovernorSteamNR.cpp
-	governors/GovernorSteamTCSR.cpp
-	governors/GovernorTgov1.cpp
-	)
-
-set (block_headers
-	Block.h
-	blocks/integralBlock.h
-	blocks/deadbandBlock.h
-	blocks/delayBlock.h
-	blocks/nullBlock.h
-	blocks/pidBlock.h
-	blocks/controlBlock.h
-	blocks/derivativeBlock.h
-	blocks/functionBlock.h
-	blocks/lutBlock.h
-	blocks/transferFunctionBlock.h
-	blocks/blockSequence.h
-	blocks/filteredDerivativeBlock.h
-	blocks/valueLimiter.h
-	blocks/rampLimiter.h
-	blocks/blockLibrary.h
+set(
+    generator_sources
+    ${generator_headers}
+    generators/Generator.cpp
+    generators/variableGenerator.cpp
+    generators/isocController.cpp
+    generators/DynamicGenerator.cpp
 )
 
-set (block_sources
-	${block_headers}
-	blocks/Block.cpp
-	blocks/integralBlock.cpp
-	blocks/deadbandBlock.cpp
-	blocks/delayBlock.cpp
-	blocks/nullBlock.cpp
-	blocks/pidBlock.cpp
-	blocks/controlBlock.cpp
-	blocks/derivativeBlock.cpp
-	blocks/functionBlock.cpp
-	blocks/lutBlock.cpp
-	blocks/transferFunctionBlock.cpp
-	blocks/filteredDerivativeBlock.cpp
-	blocks/blockSequence.cpp
-	blocks/valueLimiter.cpp
-	blocks/rampLimiter.cpp
-	)
+set(
+    gridSource_headers
+    Source.h
+    sources/sourceTypes.h
+    sources/rampSource.h
+    sources/fileSource.h
+    sources/randomSource.h
+    sources/pulseSource.h
+    sources/sineSource.h
+    sources/functionSource.h
+    sources/commSource.h
+    sources/blockSource.h
+    sources/grabberSource.h
+)
 
-set(submodel_sources
-	${genmodel_sources}
-	${exciter_sources}
-	${gov_sources}
-	${gridSource_sources}
-	${block_sources}
-	)
+set(
+    gridSource_sources
+    ${gridSource_headers}
+    sources/Source.cpp
+    sources/rampSource.cpp
+    sources/fileSource.cpp
+    sources/randomSource.cpp
+    sources/pulseSource.cpp
+    sources/sineSource.cpp
+    sources/functionSource.cpp
+    sources/commSource.cpp
+    sources/blockSource.cpp
+    sources/grabberSource.cpp
+)
 
-set(load_headers
+set(
+    exciter_headers
+    Exciter.h
+    Stabilizer.h
+    exciters/ExciterDC1A.h
+    exciters/ExciterDC2A.h
+    exciters/ExciterIEEEtype1.h
+    exciters/ExciterIEEEtype2.h
+)
 
-	Load.h
-	loads/rampLoad.h
-	loads/exponentialLoad.h
-	loads/sourceLoad.h
-	loads/fileLoad.h
-	loads/fDepLoad.h
-	loads/motorLoad.h
-	loads/motorLoad3.h
-	loads/motorLoad5.h
-	loads/gridLabDLoad.h
-	loads/svd.h
-	loads/aggregateLoad.h
-	loads/zipLoad.h
-	loads/frequencySensitiveLoad.h
-	loads/ThreePhaseLoad.h
-	)
+set(
+    exciter_sources
+    ${exciter_headers}
+    exciters/Exciter.cpp
+    exciters/ExciterDC1A.cpp
+    exciters/ExciterDC2A.cpp
+    exciters/ExciterIEEEtype1.cpp
+    exciters/ExciterIEEEtype2.cpp
+    stabilizers/Stabilizer.cpp
+)
 
-set(load_sources
-	${load_headers}
-	loads/Load.cpp
-	loads/rampLoad.cpp
-	loads/fileLoad.cpp
-	loads/motorLoad.cpp
-	loads/motorLoad3.cpp
-	loads/motorLoad5.cpp
-	loads/approximatingLoad.cpp
-	loads/exponentialLoad.cpp
-	loads/fDepLoad.cpp
-	loads/aggregateLoad.cpp
-	loads/sourceLoad.cpp
-	loads/zipLoad.cpp
-	loads/svd.cpp
-	loads/ThreePhaseLoad.cpp
-	loads/frequencySensitiveLoad.cpp
-	loads/gridLabDLoad.cpp
-	)
+set(
+    gov_headers
+    Governor.h
+    governors/GovernorTypes.h
+    governors/GovernorHydro.h
+    governors/GovernorIeeeSimple.h
+    governors/GovernorReheat.h
+    governors/GovernorSteamNR.h
+    governors/GovernorSteamTCSR.h
+    governors/GovernorTgov1.h
+)
 
-set (link_headers
-	links/dcLink.h
-	links/acdcConverter.h
-	links/adjustableTransformer.h
-	Link.h
-	links/subsystem.h
-	links/hvdc.h
-	links/zBreaker.h
-	links/longLine.h
-	links/acLine.h
-	)
+set(
+    gov_sources
+    ${gov_headers}
+    governors/Governor.cpp
+    governors/GovernorHydro.cpp
+    governors/GovernorIeeeSimple.cpp
+    governors/GovernorReheat.cpp
+    governors/GovernorSteamNR.cpp
+    governors/GovernorSteamTCSR.cpp
+    governors/GovernorTgov1.cpp
+)
 
-set(link_sources
-	${link_headers}
-	links/Link.cpp
-	links/adjustableTransformer.cpp
-	links/dcLink.cpp
-	links/acdcConverter.cpp
-	links/subsystem.cpp
-	links/hvdc.cpp
-	links/zBreaker.cpp
-	links/longLine.cpp
-	links/acLine.cpp
-	)
+set(
+    block_headers
+    Block.h
+    blocks/integralBlock.h
+    blocks/deadbandBlock.h
+    blocks/delayBlock.h
+    blocks/nullBlock.h
+    blocks/pidBlock.h
+    blocks/controlBlock.h
+    blocks/derivativeBlock.h
+    blocks/functionBlock.h
+    blocks/lutBlock.h
+    blocks/transferFunctionBlock.h
+    blocks/blockSequence.h
+    blocks/filteredDerivativeBlock.h
+    blocks/valueLimiter.h
+    blocks/rampLimiter.h
+    blocks/blockLibrary.h
+)
 
-set(simulation_headers
-	simulation/contingency.h
-	simulation/continuation.h
-	gridDynSimulation.h
-	simulation/gridSimulation.h
-	simulation/diagnostics.h
-	simulation/powerFlowErrorRecovery.h
-	simulation/dynamicInitialConditionRecovery.h
-	simulation/faultResetRecovery.h
-	simulation/gridDynActions.h
-	simulation/gridDynSimulationFileOps.h
-	)
+set(
+    block_sources
+    ${block_headers}
+    blocks/Block.cpp
+    blocks/integralBlock.cpp
+    blocks/deadbandBlock.cpp
+    blocks/delayBlock.cpp
+    blocks/nullBlock.cpp
+    blocks/pidBlock.cpp
+    blocks/controlBlock.cpp
+    blocks/derivativeBlock.cpp
+    blocks/functionBlock.cpp
+    blocks/lutBlock.cpp
+    blocks/transferFunctionBlock.cpp
+    blocks/filteredDerivativeBlock.cpp
+    blocks/blockSequence.cpp
+    blocks/valueLimiter.cpp
+    blocks/rampLimiter.cpp
+)
 
-set(simulation_sources
-	${simulation_headers}
+set(
+    submodel_sources
+    ${genmodel_sources}
+    ${exciter_sources}
+    ${gov_sources}
+    ${gridSource_sources}
+    ${block_sources}
+)
+
+set(
+    load_headers
+    Load.h
+    loads/rampLoad.h
+    loads/exponentialLoad.h
+    loads/sourceLoad.h
+    loads/fileLoad.h
+    loads/fDepLoad.h
+    loads/motorLoad.h
+    loads/motorLoad3.h
+    loads/motorLoad5.h
+    loads/gridLabDLoad.h
+    loads/svd.h
+    loads/aggregateLoad.h
+    loads/zipLoad.h
+    loads/frequencySensitiveLoad.h
+    loads/ThreePhaseLoad.h
+)
+
+set(
+    load_sources
+    ${load_headers}
+    loads/Load.cpp
+    loads/rampLoad.cpp
+    loads/fileLoad.cpp
+    loads/motorLoad.cpp
+    loads/motorLoad3.cpp
+    loads/motorLoad5.cpp
+    loads/approximatingLoad.cpp
+    loads/exponentialLoad.cpp
+    loads/fDepLoad.cpp
+    loads/aggregateLoad.cpp
+    loads/sourceLoad.cpp
+    loads/zipLoad.cpp
+    loads/svd.cpp
+    loads/ThreePhaseLoad.cpp
+    loads/frequencySensitiveLoad.cpp
+    loads/gridLabDLoad.cpp
+)
+
+set(
+    link_headers
+    links/dcLink.h
+    links/acdcConverter.h
+    links/adjustableTransformer.h
+    Link.h
+    links/subsystem.h
+    links/hvdc.h
+    links/zBreaker.h
+    links/longLine.h
+    links/acLine.h
+)
+
+set(
+    link_sources
+    ${link_headers}
+    links/Link.cpp
+    links/adjustableTransformer.cpp
+    links/dcLink.cpp
+    links/acdcConverter.cpp
+    links/subsystem.cpp
+    links/hvdc.cpp
+    links/zBreaker.cpp
+    links/longLine.cpp
+    links/acLine.cpp
+)
+
+set(
+    simulation_headers
+    simulation/contingency.h
+    simulation/continuation.h
+    gridDynSimulation.h
+    simulation/gridSimulation.h
+    simulation/diagnostics.h
+    simulation/powerFlowErrorRecovery.h
+    simulation/dynamicInitialConditionRecovery.h
+    simulation/faultResetRecovery.h
+    simulation/gridDynActions.h
+    simulation/gridDynSimulationFileOps.h
+)
+
+set(
+    simulation_sources
+    ${simulation_headers}
     simulation/gridDynContinuation.cpp
-	simulation/gridDynSimulation.cpp
-	simulation/contingency.cpp
-	simulation/gridDynPowerFlow.cpp
-	simulation/gridDynDynamic.cpp
-	simulation/gridSimulation.cpp
-	simulation/gridDynActions.cpp
-	simulation/gridDynSimulationFileOps.cpp
-	simulation/diagnostics.cpp
-	simulation/powerFlowErrorRecovery.cpp
-	simulation/dynamicInitialConditionRecovery.cpp
-	simulation/faultResetRecovery.cpp
-	simulation/gridDynContingency.cpp
-
-	)
-
-set(solver_headers
-	solvers/solverInterface.h
-	solvers/sundialsInterface.h
-	solvers/idaInterface.h
-	solvers/kinsolInterface.h
-	solvers/basicSolver.h
-	solvers/sundialsMatrixData.h
-	solvers/basicOdeSolver.h
-	solvers/solverMode.hpp
-	)
-
-set(solver_sources
-	${solver_headers}
-	solvers/idaInterface.cpp
-	solvers/kinsolInterface.cpp
-	solvers/solverInterface.cpp
-	solvers/basicSolver.cpp
-	solvers/sundialsMatrixData.cpp
-	solvers/sundialsMatrixDataDense.cpp
-	solvers/sundialsMatrixDataSparseRow.cpp
-	solvers/sundialsMatrixDataSparseColumn.cpp
-	solvers/sundialsInterface.cpp
-	solvers/basicOdeSolver.cpp
-	)
-
-IF (LOAD_CVODE)
-	list(APPEND solver_sources
-	solvers/cvodeInterface.cpp
-	solvers/cvodeInterface.h
-	)
-
-	list(APPEND solver_headers
-	solvers/cvodeInterface.h
-	)
-
-ENDIF(LOAD_CVODE)
-
-IF (LOAD_ARKODE)
-	list(APPEND solver_sources
-	solvers/arkodeInterface.cpp
-	solvers/arkodeInterface.h
-	)
-
-	list(APPEND solver_headers
-	solvers/arkodeInterface.h
-	)
-ENDIF(LOAD_ARKODE)
-
-set (core_headers
-	gridComponent.h
-	gridPrimary.h
-	gridSecondary.h
-	gridSubModel.h
-	gridComponentHelperClasses.h
-	numericEstimationFunctions.h
-	gridDynDefinitions.hpp
-	)
-
-set (core_sources
-	${core_headers}
-	gridComponent.cpp
-	gridPrimary.cpp
-	gridSecondary.cpp
-	gridSubModel.cpp
-	gridComponentHelperClasses.cpp
-	numericEstimationFunctions.cpp
-	)
-
-set(primary_headers
-	gridBus.h
-	Area.h
-	primary/dcBus.h
-	allGridDynObjects.h
-	primary/BusControls.h
-	primary/listMaintainer.h
-	primary/infiniteBus.h
-	primary/acBus.h
-	primary/DcBusControls.h
-	)
-
-set(primary_sources
-	${primary_headers}
-	primary/gridBus.cpp
-	primary/Area.cpp
-	primary/dcBus.cpp
-	primary/infiniteBus.cpp
-	primary/BusControls.cpp
-	primary/DcBusControls.cpp
-	primary/acBus.cpp
-	primary/listMaintainer.cpp
-	)
-
-set(event_headers
-	events/Event.h
-	events/eventAdapters.h
-	events/eventQueue.h
-	events/eventInterface.hpp
-	events/reversibleEvent.h
-	events/parameterOperator.h
-	events/Player.h
-	events/interpolatingPlayer.h
-	events/compoundEvent.h
-	events/compoundEventPlayer.h
-	)
-
-set(event_sources
-	${event_headers}
-	events/Event.cpp
-	events/eventAdapters.cpp
-	events/eventQueue.cpp
-	events/Player.cpp
-	events/interpolatingPlayer.cpp
-	events/compoundEvent.cpp
-	events/compoundEventPlayer.cpp
-	events/reversibleEvent.cpp
-	events/parameterOperator.cpp
-	)
-set(measurement_headers
-	measurement/gridGrabbers.h
-	measurement/objectGrabbers.h
-	measurement/collector.h
-	measurement/Recorder.h
-	measurement/stateGrabber.h
-	measurement/Condition.h
-	measurement/grabberSet.h
-	measurement/grabberInterpreter.hpp
-	)
-
-set(measurement_sources
-	${measurement_headers}
-	measurement/Recorder.cpp
-	measurement/gridGrabbers.cpp
-	measurement/grabberInterpreter.cpp
-	measurement/stateGrabbers.cpp
-	measurement/Condition.cpp
-	measurement/objectGrabbers.cpp
-	measurement/compoundCondition.cpp
-	measurement/collector.cpp
-	measurement/grabberSet.cpp
-	)
-
-set (comm_headers
-	comms/commMessage.h
-	comms/Communicator.h
-	comms/communicationsCore.h
-	comms/schedulerMessage.h
-	comms/controlMessage.h
-	comms/commManager.h
-	)
-
-set (comm_sources
-	${comm_headers}
-	comms/commMessage.cpp
-	comms/Communicator.cpp
-	comms/communicationsCore.cpp
-	comms/schedulerMessage.cpp
-	comms/controlMessage.cpp
-	comms/commManager.cpp
-	)
-
-set(relay_headers
-	Relay.h
-	relays/zonalRelay.h
-	relays/loadRelay.h
-	relays/busRelay.h
-	relays/fuse.h
-	relays/breaker.h
-	relays/sensor.h
-	relays/differentialRelay.h
-	relays/controlRelay.h
-	relays/pmu.h
-	)
-
-set (relay_sources
-	${relay_headers}
-	relays/Relay.cpp
-	relays/zonalRelay.cpp
-	relays/loadRelay.cpp
-	relays/busRelay.cpp
-	relays/fuse.cpp
-	relays/breaker.cpp
-	relays/sensor.cpp
-	relays/differentialRelay.cpp
-	relays/controlRelay.cpp
-	relays/pmu.cpp
+    simulation/gridDynSimulation.cpp
+    simulation/contingency.cpp
+    simulation/gridDynPowerFlow.cpp
+    simulation/gridDynDynamic.cpp
+    simulation/gridSimulation.cpp
+    simulation/gridDynActions.cpp
+    simulation/gridDynSimulationFileOps.cpp
+    simulation/diagnostics.cpp
+    simulation/powerFlowErrorRecovery.cpp
+    simulation/dynamicInitialConditionRecovery.cpp
+    simulation/faultResetRecovery.cpp
+    simulation/gridDynContingency.cpp
 )
 
+set(
+    solver_headers
+    solvers/solverInterface.h
+    solvers/sundialsInterface.h
+    solvers/idaInterface.h
+    solvers/kinsolInterface.h
+    solvers/basicSolver.h
+    solvers/sundialsMatrixData.h
+    solvers/basicOdeSolver.h
+    solvers/solverMode.hpp
+)
 
-set (controller_headers
-	controllers/schedulerInfo.h
-	controllers/scheduler.h
-	controllers/reserveDispatcher.h
-	controllers/AGControl.h
-	controllers/controlSystem.h
-	controllers/dispatcher.h
-	)
+set(
+    solver_sources
+    ${solver_headers}
+    solvers/idaInterface.cpp
+    solvers/kinsolInterface.cpp
+    solvers/solverInterface.cpp
+    solvers/basicSolver.cpp
+    solvers/sundialsMatrixData.cpp
+    solvers/sundialsMatrixDataDense.cpp
+    solvers/sundialsMatrixDataSparseRow.cpp
+    solvers/sundialsMatrixDataSparseColumn.cpp
+    solvers/sundialsInterface.cpp
+    solvers/basicOdeSolver.cpp
+)
 
-set (controller_sources
-	${controller_headers}
-	controllers/scheduler.cpp
-	controllers/schedulerRamp.cpp
-	controllers/schedulerReg.cpp
-	controllers/reserveDispatcher.cpp
-	controllers/controlSystem.cpp
-	controllers/AGControl.cpp
-	controllers/dispatcher.cpp
-	)
+if(LOAD_CVODE)
+    list(
+        APPEND
+            solver_sources solvers/cvodeInterface.cpp solvers/cvodeInterface.h
+    )
 
-set(sublibrary_files
-	${event_sources}
-	${measurement_sources}
-	${griddynIO_sources}
-	${gridSource_sources}
-	${controller_sources}
-	${comm_sources}
-	${solver_sources}
-	)
+    list(APPEND solver_headers solvers/cvodeInterface.h)
 
-set(model_files
-	${relay_sources}
-	${submodel_sources}
-	${load_sources}
-	${link_sources}
-	${generator_sources}
-	)
+endif(LOAD_CVODE)
 
+if(LOAD_ARKODE)
+    list(
+        APPEND
+            solver_sources solvers/arkodeInterface.cpp solvers/arkodeInterface.h
+    )
 
-set(header_files
-${exciter_headers}
-${gov_headers}
-${block_headers}
-	${gridSource_headers}
-	${core_headers}
-	${primary_headers}
-	${link_headers}
-	${solver_headers}
-	${controller_headers}
-	${comm_headers}
-	${event_headers}
-	${measurement_headers}
-	${gridDynIO_headers}
-	${simulation_headers}
-	${submodel_headers}
-	${load_headers}
-	${relay_headers}
-	${generator_headers}
-	)
+    list(APPEND solver_headers solvers/arkodeInterface.h)
+endif(LOAD_ARKODE)
 
-add_library(griddyn STATIC ${simulation_sources} ${model_files} ${core_sources} ${primary_sources} ${sublibrary_files})
+set(
+    core_headers
+    gridComponent.h
+    gridPrimary.h
+    gridSecondary.h
+    gridSubModel.h
+    gridComponentHelperClasses.h
+    numericEstimationFunctions.h
+    gridDynDefinitions.hpp
+)
+
+set(
+    core_sources
+    ${core_headers}
+    gridComponent.cpp
+    gridPrimary.cpp
+    gridSecondary.cpp
+    gridSubModel.cpp
+    gridComponentHelperClasses.cpp
+    numericEstimationFunctions.cpp
+)
+
+set(
+    primary_headers
+    gridBus.h
+    Area.h
+    primary/dcBus.h
+    allGridDynObjects.h
+    primary/BusControls.h
+    primary/listMaintainer.h
+    primary/infiniteBus.h
+    primary/acBus.h
+    primary/DcBusControls.h
+)
+
+set(
+    primary_sources
+    ${primary_headers}
+    primary/gridBus.cpp
+    primary/Area.cpp
+    primary/dcBus.cpp
+    primary/infiniteBus.cpp
+    primary/BusControls.cpp
+    primary/DcBusControls.cpp
+    primary/acBus.cpp
+    primary/listMaintainer.cpp
+)
+
+set(
+    event_headers
+    events/Event.h
+    events/eventAdapters.h
+    events/eventQueue.h
+    events/eventInterface.hpp
+    events/reversibleEvent.h
+    events/parameterOperator.h
+    events/Player.h
+    events/interpolatingPlayer.h
+    events/compoundEvent.h
+    events/compoundEventPlayer.h
+)
+
+set(
+    event_sources
+    ${event_headers}
+    events/Event.cpp
+    events/eventAdapters.cpp
+    events/eventQueue.cpp
+    events/Player.cpp
+    events/interpolatingPlayer.cpp
+    events/compoundEvent.cpp
+    events/compoundEventPlayer.cpp
+    events/reversibleEvent.cpp
+    events/parameterOperator.cpp
+)
+set(
+    measurement_headers
+    measurement/gridGrabbers.h
+    measurement/objectGrabbers.h
+    measurement/collector.h
+    measurement/Recorder.h
+    measurement/stateGrabber.h
+    measurement/Condition.h
+    measurement/grabberSet.h
+    measurement/grabberInterpreter.hpp
+)
+
+set(
+    measurement_sources
+    ${measurement_headers}
+    measurement/Recorder.cpp
+    measurement/gridGrabbers.cpp
+    measurement/grabberInterpreter.cpp
+    measurement/stateGrabbers.cpp
+    measurement/Condition.cpp
+    measurement/objectGrabbers.cpp
+    measurement/compoundCondition.cpp
+    measurement/collector.cpp
+    measurement/grabberSet.cpp
+)
+
+set(
+    comm_headers
+    comms/commMessage.h
+    comms/Communicator.h
+    comms/communicationsCore.h
+    comms/schedulerMessage.h
+    comms/controlMessage.h
+    comms/commManager.h
+)
+
+set(
+    comm_sources
+    ${comm_headers}
+    comms/commMessage.cpp
+    comms/Communicator.cpp
+    comms/communicationsCore.cpp
+    comms/schedulerMessage.cpp
+    comms/controlMessage.cpp
+    comms/commManager.cpp
+)
+
+set(
+    relay_headers
+    Relay.h
+    relays/zonalRelay.h
+    relays/loadRelay.h
+    relays/busRelay.h
+    relays/fuse.h
+    relays/breaker.h
+    relays/sensor.h
+    relays/differentialRelay.h
+    relays/controlRelay.h
+    relays/pmu.h
+)
+
+set(
+    relay_sources
+    ${relay_headers}
+    relays/Relay.cpp
+    relays/zonalRelay.cpp
+    relays/loadRelay.cpp
+    relays/busRelay.cpp
+    relays/fuse.cpp
+    relays/breaker.cpp
+    relays/sensor.cpp
+    relays/differentialRelay.cpp
+    relays/controlRelay.cpp
+    relays/pmu.cpp
+)
+
+set(
+    controller_headers
+    controllers/schedulerInfo.h
+    controllers/scheduler.h
+    controllers/reserveDispatcher.h
+    controllers/AGControl.h
+    controllers/controlSystem.h
+    controllers/dispatcher.h
+)
+
+set(
+    controller_sources
+    ${controller_headers}
+    controllers/scheduler.cpp
+    controllers/schedulerRamp.cpp
+    controllers/schedulerReg.cpp
+    controllers/reserveDispatcher.cpp
+    controllers/controlSystem.cpp
+    controllers/AGControl.cpp
+    controllers/dispatcher.cpp
+)
+
+set(
+    sublibrary_files
+    ${event_sources}
+    ${measurement_sources}
+    ${griddynIO_sources}
+    ${gridSource_sources}
+    ${controller_sources}
+    ${comm_sources}
+    ${solver_sources}
+)
+
+set(
+    model_files
+    ${relay_sources}
+    ${submodel_sources}
+    ${load_sources}
+    ${link_sources}
+    ${generator_sources}
+)
+
+set(
+    header_files
+    ${exciter_headers}
+    ${gov_headers}
+    ${block_headers}
+    ${gridSource_headers}
+    ${core_headers}
+    ${primary_headers}
+    ${link_headers}
+    ${solver_headers}
+    ${controller_headers}
+    ${comm_headers}
+    ${event_headers}
+    ${measurement_headers}
+    ${gridDynIO_headers}
+    ${simulation_headers}
+    ${submodel_headers}
+    ${load_headers}
+    ${relay_headers}
+    ${generator_headers}
+)
+
+add_library(
+    griddyn
+    STATIC
+    ${simulation_sources}
+    ${model_files}
+    ${core_sources}
+    ${primary_sources}
+    ${sublibrary_files}
+)
 
 target_link_libraries(griddyn PUBLIC coreObjects)
-
 
 target_link_libraries(griddyn PUBLIC SUNDIALS::SUNDIALS)
 target_link_libraries(griddyn PUBLIC coupling_static_lib)
 if(NOT DISABLE_KLU)
-	target_link_libraries(griddyn PUBLIC SuiteSparse::klu)
+    target_link_libraries(griddyn PUBLIC SuiteSparse::klu)
 endif(NOT DISABLE_KLU)
 
 source_group("loads" FILES ${load_sources})
@@ -544,12 +581,26 @@ source_group("controllers" FILES ${controller_sources})
 source_group("blocks" FILES ${block_sources})
 source_group("solvers" FILES ${solver_sources})
 
-#create a griddyn_config.h file for program options
-CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/config/griddyn-config.h.in ${AUTOBUILD_INSTALL_PATH}/include/griddyn/griddyn-config.h)
-INSTALL(FILES ${AUTOBUILD_INSTALL_PATH}/include/griddyn/griddyn-config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn COMPONENT headers)
+# create a griddyn_config.h file for program options
+configure_file(
+    ${PROJECT_SOURCE_DIR}/config/griddyn-config.h.in
+    ${AUTOBUILD_INSTALL_PATH}/include/griddyn/griddyn-config.h
+)
+install(
+    FILES ${AUTOBUILD_INSTALL_PATH}/include/griddyn/griddyn-config.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn
+    COMPONENT headers
+)
 
-INSTALL(TARGETS griddyn EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS griddyn
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${header_files}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/griddyn
-  COMPONENT headers)
+install(
+    FILES ${header_files}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/griddyn
+    COMPONENT headers
+)

--- a/src/griddyn_shared/CMakeLists.txt
+++ b/src/griddyn_shared/CMakeLists.txt
@@ -8,68 +8,111 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-
-set(griddyn_lib_public_headers
-griddyn.h
-griddyn_export.h
-griddyn_export_advanced.h
-
+set(
+    griddyn_lib_public_headers
+    griddyn.h
+    griddyn_export.h
+    griddyn_export_advanced.h
 )
 
-set(griddyn_lib_internal_headers
-internal/griddyn_export_internal.h
-)
+set(griddyn_lib_internal_headers internal/griddyn_export_internal.h)
 
-set(griddyn_lib_sources
-griddyn_exportObjects.cpp
-griddyn_exportSimulation.cpp
-griddyn_exportQueries.cpp
-griddyn_exportMathFunctions.cpp
-griddyn_exportObjectMathFunctions.cpp
-griddyn_exportEvents.cpp
+set(
+    griddyn_lib_sources
+    griddyn_exportObjects.cpp
+    griddyn_exportSimulation.cpp
+    griddyn_exportQueries.cpp
+    griddyn_exportMathFunctions.cpp
+    griddyn_exportObjectMathFunctions.cpp
+    griddyn_exportEvents.cpp
 )
 
 include(GenerateExportHeader)
 
-add_library(griddyn_shared_lib SHARED ${griddyn_lib_sources} ${griddyn_lib_public_headers} ${griddyn_lib_internal_headers})
-
-set_target_properties(griddyn_shared_lib PROPERTIES CXX_VISIBILITY_PRESET hidden C_VISIBILITY_PRESET hidden)
-
-generate_export_header(griddyn_shared_lib
-	BASE_NAME griddyn
-    EXPORT_FILE_NAME griddyn_shared_export.h)
-	
-target_include_directories(griddyn_shared_lib PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+add_library(
+    griddyn_shared_lib
+    SHARED
+    ${griddyn_lib_sources}
+    ${griddyn_lib_public_headers}
+    ${griddyn_lib_internal_headers}
 )
 
-set_target_properties (griddyn_shared_lib PROPERTIES FOLDER interfaces)
+set_target_properties(
+    griddyn_shared_lib
+    PROPERTIES
+        CXX_VISIBILITY_PRESET
+        hidden
+        C_VISIBILITY_PRESET
+        hidden
+)
 
+generate_export_header(
+    griddyn_shared_lib
+    BASE_NAME
+    griddyn
+    EXPORT_FILE_NAME
+    griddyn_shared_export.h
+)
+
+target_include_directories(
+    griddyn_shared_lib
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+
+set_target_properties(griddyn_shared_lib PROPERTIES FOLDER interfaces)
 
 target_link_libraries(griddyn_shared_lib PRIVATE runner)
-if (UNIX OR MINGW)
-	if (NOT APPLE)
-		target_link_libraries(griddyn_shared_lib PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/export.txt)
-	endif(NOT APPLE)
+if(UNIX OR MINGW)
+    if(NOT APPLE)
+        target_link_libraries(
+            griddyn_shared_lib
+            PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/export.txt
+        )
+    endif(NOT APPLE)
 endif()
 
-INSTALL(TARGETS griddyn_shared_lib EXPORT griddyn-targets
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(
+    TARGETS griddyn_shared_lib
+    EXPORT griddyn-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.6)
-	INSTALL(FILES $<TARGET_FILE:griddyn_shared_lib> DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime EXCLUDE_FROM_ALL)
-INSTALL(FILES $<TARGET_LINKER_FILE:griddyn_shared_lib> DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries EXCLUDE_FROM_ALL)
-ELSE()
-	INSTALL(FILES $<TARGET_FILE:griddyn_shared_lib> DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
-INSTALL(FILES $<TARGET_LINKER_FILE:griddyn_shared_lib> DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-ENDIF()
+if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.6)
+    install(
+        FILES $<TARGET_FILE:griddyn_shared_lib>
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT
+        RUNTIME EXCLUDE_FROM_ALL
+    )
+    install(
+        FILES $<TARGET_LINKER_FILE:griddyn_shared_lib>
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries EXCLUDE_FROM_ALL
+    )
+else()
+    install(
+        FILES $<TARGET_FILE:griddyn_shared_lib>
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT
+        RUNTIME
+    )
+    install(
+        FILES $<TARGET_LINKER_FILE:griddyn_shared_lib>
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries
+    )
+endif()
 
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/griddyn_shared_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/shared
+    COMPONENT headers
+)
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/griddyn_shared_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/shared COMPONENT headers)
-
-
-INSTALL(FILES ${griddyn_lib_public_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/shared
-  COMPONENT headers)
+install(
+    FILES ${griddyn_lib_public_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/shared
+    COMPONENT headers
+)

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -11,71 +11,97 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(griddynHELICS_sources
-	helicsSource.cpp
-	helicsCollector.cpp
-	helicsGhostBus.cpp
-	helicsLoad.cpp
-	helicsLibrary.cpp
-	helicsSupport.cpp
-	helicsRunner.cpp
-	helicsCoordinator.cpp
-	helicsCommunicator.cpp
-	)
+set(
+    griddynHELICS_sources
+    helicsSource.cpp
+    helicsCollector.cpp
+    helicsGhostBus.cpp
+    helicsLoad.cpp
+    helicsLibrary.cpp
+    helicsSupport.cpp
+    helicsRunner.cpp
+    helicsCoordinator.cpp
+    helicsCommunicator.cpp
+)
 
-set(griddynHELICS_headers
-	helicsLibrary.h
-	helicsSource.h
-	helicsCollector.h
-	helicsGhostBus.h
-	helicsLoad.h
-	helicsRunner.h
-	helicsSupport.h
-	helicsCoordinator.h
-	helicsCommunicator.h
-	)
-
+set(
+    griddynHELICS_headers
+    helicsLibrary.h
+    helicsSource.h
+    helicsCollector.h
+    helicsGhostBus.h
+    helicsLoad.h
+    helicsRunner.h
+    helicsSupport.h
+    helicsCoordinator.h
+    helicsCommunicator.h
+)
 
 add_library(helicsLib STATIC ${griddynHELICS_sources} ${griddynHELICS_headers})
 
-set_target_properties (helicsLib PROPERTIES FOLDER libraries)
+set_target_properties(helicsLib PROPERTIES FOLDER libraries)
 
 message(STATUS "helics include ${HELICS_INCLUDE_DIR}")
 message(STATUS "helics libraries ${HELICS_STATIC_LIBRARY}")
 
-FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test test_dir)
+file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test test_dir)
 
-IF(WIN32)
-#there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
-# to get the regex to work and I need two for visual studio to actually print it.
-# thus to it looks like this to replace '\' with '\\'
-#this will probably fail on macs yet
+if(WIN32)
+    # there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
+    # to get the regex to work and I need two for visual studio to actually print it.
+    # thus to it looks like this to replace '\' with '\\'
+    # this will probably fail on macs yet
 
-STRING(REGEX REPLACE "\\\\" "\\\\\\\\" test_dir ${test_dir})
-ENDIF(WIN32)
-#message(${test_dir})
+    string(
+        REGEX
+        REPLACE
+            "\\\\"
+            "\\\\\\\\"
+            test_dir
+            ${test_dir}
+    )
+endif(WIN32)
+# message(${test_dir})
 
-target_compile_definitions(helicsLib PUBLIC -DHELICS_TEST_DIRECTORY="${test_dir}" )
+target_compile_definitions(
+    helicsLib PUBLIC -DHELICS_TEST_DIRECTORY="${test_dir}"
+)
 
-target_compile_definitions(helicsLib PUBLIC -DHELICS_BROKER_EXECUTABLE="${HELICS_BROKER}")
+target_compile_definitions(
+    helicsLib PUBLIC -DHELICS_BROKER_EXECUTABLE="${HELICS_BROKER}"
+)
 
-target_compile_definitions(helicsLib PUBLIC -DHELICS_PLAYER_EXECUTABLE="${HELICS_PLAYER}")
-target_compile_definitions(helicsLib PUBLIC -DHELICS_RECORDER_EXECUTABLE="${HELICS_RECORDER}")
+target_compile_definitions(
+    helicsLib PUBLIC -DHELICS_PLAYER_EXECUTABLE="${HELICS_PLAYER}"
+)
+target_compile_definitions(
+    helicsLib PUBLIC -DHELICS_RECORDER_EXECUTABLE="${HELICS_RECORDER}"
+)
 
 target_link_libraries(helicsLib PUBLIC HELICS::helics-static runner)
 
-list (APPEND optional_library_key_headers helics/helicsLibrary.h)
-list (APPEND optional_library_functions loadHELICSLibrary)
+list(APPEND optional_library_key_headers helics/helicsLibrary.h)
+list(APPEND optional_library_functions loadHELICSLibrary)
 
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)
 
+list(
+    APPEND
+        optional_component_test_files
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/helicsTest.cpp
+)
+set(optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
 
-list(APPEND optional_component_test_files ${CMAKE_CURRENT_SOURCE_DIR}/test/helicsTest.cpp)
-set (optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
+install(
+    TARGETS helicsLib
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(TARGETS helicsLib EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-
-INSTALL(FILES ${griddynHELICS_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/helics
-   COMPONENT headers)
+install(
+    FILES ${griddynHELICS_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/helics
+    COMPONENT headers
+)

--- a/src/networking/CMakeLists.txt
+++ b/src/networking/CMakeLists.txt
@@ -8,128 +8,139 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(networking_sources
-	networkingInterface.cpp)
-set(networking_headers
-	networkingInterface.h)
+set(networking_sources networkingInterface.cpp)
+set(networking_headers networkingInterface.h)
 
-if ((ZMQ_ENABLE) OR (ZMQ_NEEDED))
-set(zmqLibrary_sources
-	zmqLibrary/zmqContextManager.cpp
-	zmqLibrary/zmqHelper.cpp
-	zmqLibrary/zmqReactor.cpp
-	zmqLibrary/zmqProxyHub.cpp
-	zmqLibrary/zmqSocketDescriptor.cpp
-	)
+if((ZMQ_ENABLE) OR (ZMQ_NEEDED))
+    set(
+        zmqLibrary_sources
+        zmqLibrary/zmqContextManager.cpp
+        zmqLibrary/zmqHelper.cpp
+        zmqLibrary/zmqReactor.cpp
+        zmqLibrary/zmqProxyHub.cpp
+        zmqLibrary/zmqSocketDescriptor.cpp
+    )
 
-set(zmqLibrary_headers
-	zmqLibrary/zmqContextManager.h
-	zmqLibrary/zmqHelper.h
-	zmqLibrary/zmqReactor.h
-	zmqLibrary/zmqProxyHub.h
-	zmqLibrary/zmqSocketDescriptor.h
-	)
+    set(
+        zmqLibrary_headers
+        zmqLibrary/zmqContextManager.h
+        zmqLibrary/zmqHelper.h
+        zmqLibrary/zmqReactor.h
+        zmqLibrary/zmqProxyHub.h
+        zmqLibrary/zmqSocketDescriptor.h
+    )
 
-set(zmqInterface_sources
-	zmqCommunicator.cpp
-	zmqInterface.cpp
-	)
+    set(zmqInterface_sources zmqCommunicator.cpp zmqInterface.cpp)
 
-set(zmqInterface_headers
-	zmqCommunicator.h
-	zmqInterface.h
-	)
+    set(zmqInterface_headers zmqCommunicator.h zmqInterface.h)
 
-list(APPEND networking_sources ${zmqLibrary_sources})
-list(APPEND networking_headers ${zmqLibrary_headers})
-list(APPEND networking_sources ${zmqInterface_sources})
-list(APPEND networking_headers ${zmqInterface_headers})
+    list(APPEND networking_sources ${zmqLibrary_sources})
+    list(APPEND networking_headers ${zmqLibrary_headers})
+    list(APPEND networking_sources ${zmqInterface_sources})
+    list(APPEND networking_headers ${zmqInterface_headers})
 
 endif()
 
+if(DIME_ENABLE)
+    set(
+        dimeInterface_sources
+        dimeCollector.cpp
+        dimeCommunicator.cpp
+        dimeClientInterface.cpp
+        dimeRunner.cpp
+        dimeInterface.cpp
+    )
 
-IF(DIME_ENABLE)
-set(dimeInterface_sources
-	dimeCollector.cpp
-	dimeCommunicator.cpp
-	dimeClientInterface.cpp
-	dimeRunner.cpp
-	dimeInterface.cpp
-	)
-
-set(dimeInterface_headers
-	dimeCollector.h
-	dimeCommunicator.h
-	dimeClientInterface.h
-	dimeRunner.h
-	dimeInterface.h
-	)
-	list(APPEND networking_sources ${dimeInterface_sources})
-	list(APPEND networking_headers ${dimeInterface_headers})
+    set(
+        dimeInterface_headers
+        dimeCollector.h
+        dimeCommunicator.h
+        dimeClientInterface.h
+        dimeRunner.h
+        dimeInterface.h
+    )
+    list(APPEND networking_sources ${dimeInterface_sources})
+    list(APPEND networking_headers ${dimeInterface_headers})
 endif()
 
-IF(TCP_ENABLE)
-set(tcpInterface_sources
-	AsioServiceManager.cpp
-	tcpCommunicator.cpp
-	tcpInterface.cpp
-	TcpHelperClasses.cpp
-	tcpCollector.cpp
-	)
+if(TCP_ENABLE)
+    set(
+        tcpInterface_sources
+        AsioServiceManager.cpp
+        tcpCommunicator.cpp
+        tcpInterface.cpp
+        TcpHelperClasses.cpp
+        tcpCollector.cpp
+    )
 
-set(tcpInterface_headers
-	AsioServiceManager.h
-	tcpCommunicator.h
-	tcpInterface.h
-	TcpHelperClasses.h
-	tcpCollector.h
-	)
-	list(APPEND networking_sources ${tcpInterface_sources})
-	list(APPEND networking_headers ${tcpInterface_headers})
+    set(
+        tcpInterface_headers
+        AsioServiceManager.h
+        tcpCommunicator.h
+        tcpInterface.h
+        TcpHelperClasses.h
+        tcpCollector.h
+    )
+    list(APPEND networking_sources ${tcpInterface_sources})
+    list(APPEND networking_headers ${tcpInterface_headers})
 endif()
 
+add_library(networking STATIC ${networking_sources} ${networking_headers})
+set_target_properties(networking PROPERTIES FOLDER libraries)
 
-add_library(networking STATIC ${networking_sources} ${networking_headers} )
-set_target_properties (networking PROPERTIES FOLDER libraries)
+install(
+    TARGETS networking
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
+if((ZMQ_ENABLE) OR (ZMQ_NEEDED))
+    target_compile_definitions(networking PRIVATE -DZMQ_ENABLE)
+    if(ZMQ_USE_STATIC_LIBRARY)
+        set(ZMQ_DEPENDENCY libzmq-static)
+        target_compile_definitions(networking PUBLIC -DZMQ_STATIC)
+    else()
+        set(ZMQ_DEPENDENCY libzmq)
+    endif()
 
-INSTALL(TARGETS networking EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+    message(STATUS "zmq lib ${ZMQ_DEPENDENCY}")
+    target_link_libraries(networking PUBLIC griddyn ${ZMQ_DEPENDENCY})
 
-if ((ZMQ_ENABLE) OR (ZMQ_NEEDED))
-target_compile_definitions(networking PRIVATE -DZMQ_ENABLE)
-if (ZMQ_USE_STATIC_LIBRARY)
-	set(ZMQ_DEPENDENCY libzmq-static)
-	target_compile_definitions(networking PUBLIC -DZMQ_STATIC)
-else()
-	set(ZMQ_DEPENDENCY libzmq)
+    source_group("ZMQLibrary" FILES ${zmqLibrary_sources} ${zmqLibrary_headers})
+    source_group(
+        "zmqinterface"
+        FILES
+        ${zmqInterface_sources}
+        ${zmqInterface_headers}
+    )
 endif()
 
-	message(STATUS "zmq lib ${ZMQ_DEPENDENCY}")
-target_link_libraries(networking PUBLIC griddyn ${ZMQ_DEPENDENCY} )
-
-source_group("ZMQLibrary" FILES ${zmqLibrary_sources} ${zmqLibrary_headers})
-source_group("zmqinterface" FILES ${zmqInterface_sources} ${zmqInterface_headers})
+if(DIME_ENABLE)
+    source_group("dime" FILES ${dimeInterface_sources} ${dimeInterface_headers})
+    target_compile_definitions(networking PRIVATE -DDIME_ENABLE)
 endif()
 
-if (DIME_ENABLE)
-	source_group("dime" FILES ${dimeInterface_sources} ${dimeInterface_headers})
-	target_compile_definitions(networking PRIVATE -DDIME_ENABLE)
+if(TCP_ENABLE)
+    source_group("tcp" FILES ${tcpInterface_sources} ${tcpInterface_headers})
+    target_compile_definitions(networking PRIVATE -DTCP_ENABLE)
 endif()
 
-if (TCP_ENABLE)
-	source_group("tcp" FILES ${tcpInterface_sources} ${tcpInterface_headers})
-	target_compile_definitions(networking PRIVATE -DTCP_ENABLE)
-endif()
+install(
+    FILES ${networking_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/networking
+    COMPONENT headers
+)
 
-INSTALL(FILES ${networking_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/networking
-  COMPONENT headers)
+list(APPEND optional_library_key_headers networking/networkingInterface.h)
+list(APPEND optional_library_functions loadNetworkingLibrary)
 
-list (APPEND optional_library_key_headers networking/networkingInterface.h)
-list (APPEND optional_library_functions loadNetworkingLibrary)
+set(optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
+set(optional_library_functions ${optional_library_functions} PARENT_SCOPE)
 
-set (optional_library_key_headers ${optional_library_key_headers} PARENT_SCOPE)
-set (optional_library_functions  ${optional_library_functions} PARENT_SCOPE)
-
-list(APPEND optional_component_test_files ${CMAKE_CURRENT_SOURCE_DIR}/test/zmqTest.cpp)
-set (optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)
+list(
+    APPEND
+        optional_component_test_files
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/zmqTest.cpp
+)
+set(optional_component_test_files ${optional_component_test_files} PARENT_SCOPE)

--- a/src/optimization/CMakeLists.txt
+++ b/src/optimization/CMakeLists.txt
@@ -1,61 +1,59 @@
 # LLNS Copyright Start
 # Copyright (c) 2014-2018, Lawrence Livermore National Security
-# This work was performed under the auspices of the U.S. Department 
-# of Energy by Lawrence Livermore National Laboratory in part under 
+# This work was performed under the auspices of the U.S. Department
+# of Energy by Lawrence Livermore National Laboratory in part under
 # Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
 # Produced at the Lawrence Livermore National Laboratory.
 # All rights reserved.
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#project  name
+# project  name
 
+set(
+    opt_sim_headers
+    optHelperClasses.h
+    gridDynOpt.h
+    gridOptObjects.h
+    optObjectFactory.h
+    optimizerInterface.h
+)
 
-set(opt_sim_headers
-optHelperClasses.h
-	gridDynOpt.h
-	gridOptObjects.h
-	optObjectFactory.h
-	optimizerInterface.h
-	)
-	
-set(opt_sim_sources
-   ${opt_sim_headers}
-   optHelperClasses.cpp
-	gridDynOpt.cpp	
-	gridOptObjects.cpp
-	optimizerInterface.cpp
-	optObjectFactory.cpp
-	)
-	
-set(opt_model_headers
-	models/gridBusOpt.h
-	models/gridLinkOpt.h
-	models/gridGenOpt.h
-	models/gridLoadOpt.h
-	models/gridAreaOpt.h
-	models/gridRelayOpt.h
-	)
+set(
+    opt_sim_sources
+    ${opt_sim_headers}
+    optHelperClasses.cpp
+    gridDynOpt.cpp
+    gridOptObjects.cpp
+    optimizerInterface.cpp
+    optObjectFactory.cpp
+)
 
-set(opt_model_sources
-	${opt_model_headers}
-	models/gridBusOpt.cpp
-	models/gridLinkOpt.cpp
-	models/gridGenOpt.cpp
-	models/gridRelayOpt.cpp
-	models/gridLoadOpt.cpp
-	models/gridAreaOpt.cpp)
+set(
+    opt_model_headers
+    models/gridBusOpt.h
+    models/gridLinkOpt.h
+    models/gridGenOpt.h
+    models/gridLoadOpt.h
+    models/gridAreaOpt.h
+    models/gridRelayOpt.h
+)
 
-set(opt_files
-	${opt_sim_sources}
-	${opt_model_sources}
-	)
+set(
+    opt_model_sources
+    ${opt_model_headers}
+    models/gridBusOpt.cpp
+    models/gridLinkOpt.cpp
+    models/gridGenOpt.cpp
+    models/gridRelayOpt.cpp
+    models/gridLoadOpt.cpp
+    models/gridAreaOpt.cpp
+)
 
-set(header_files
-	${opt_sim_headers}
-	${opt_models_headers}
-	)
-	
+set(opt_files ${opt_sim_sources} ${opt_model_sources})
+
+set(header_files ${opt_sim_headers} ${opt_models_headers})
+
 add_library(optimization STATIC ${opt_files})
 
 target_link_libraries(optimization PUBLIC griddyn)
@@ -63,9 +61,15 @@ target_link_libraries(optimization PUBLIC griddyn)
 source_group("optimization" FILES ${opt_sim_sources})
 source_group("models" FILES ${opt_model_sources})
 
-INSTALL(TARGETS optimization EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries})
+install(
+    TARGETS optimization
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries}
+)
 
-INSTALL(FILES ${header_files}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/optimization
-   COMPONENT headers)
-
+install(
+    FILES ${header_files}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/optimization
+    COMPONENT headers
+)

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,30 +1,22 @@
 # LLNS Copyright Start
 # Copyright (c) 2016, Lawrence Livermore National Security
-# This work was performed under the auspices of the U.S. Department 
-# of Energy by Lawrence Livermore National Laboratory in part under 
+# This work was performed under the auspices of the U.S. Department
+# of Energy by Lawrence Livermore National Laboratory in part under
 # Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
 # Produced at the Lawrence Livermore National Laboratory.
 # All rights reserved.
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(plugin_sources
-	gridDynPlugins.cpp
-	)
-	
-set(plugin_headers
-	gridDynPluginApi.h
-	gridDynPlugins.h
-	)
+set(plugin_sources gridDynPlugins.cpp)
+
+set(plugin_headers gridDynPluginApi.h gridDynPlugins.h)
 
 add_library(pluginLibrary ${plugin_sources} ${plugin_headers})
 
-INCLUDE_DIRECTORIES(.)
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/griddyn)
+include_directories(.)
+include_directories(${PROJECT_SOURCE_DIR}/src/griddyn)
 
-INSTALL(TARGETS pluginLibrary
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib)
+install(TARGETS pluginLibrary LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 
-INSTALL(FILES ${plugin_headers} DESTINATION include/plugins)
-
+install(FILES ${plugin_headers} DESTINATION include/plugins)

--- a/src/runner/CMakeLists.txt
+++ b/src/runner/CMakeLists.txt
@@ -8,24 +8,25 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set (runner_sources
-	gridDynRunner.cpp
-	)
+set(runner_sources gridDynRunner.cpp)
 
-set(runner_headers
-	gridDynRunner.h
-	)
-
+set(runner_headers gridDynRunner.h)
 
 add_library(runner STATIC ${runner_sources} ${runner_headers})
 
 target_link_libraries(runner PUBLIC fileInput)
 
-set_target_properties (runner PROPERTIES FOLDER libraries)
+set_target_properties(runner PROPERTIES FOLDER libraries)
 
-INSTALL(TARGETS runner EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS runner
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-INSTALL(FILES ${runner_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/runner
-  COMPONENT headers)
-
+install(
+    FILES ${runner_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/runner
+    COMPONENT headers
+)

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -8,78 +8,80 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#project name
+# project name
 
-set(utilities_sources
-	gridRandom.cpp
-	saturation.cpp
-	stringOps.cpp
-	string_viewOps.cpp
-	ThreePhaseFunctions.cpp
-	matrixOps.cpp
-	stringConversion.cpp
-	units.cpp
-	vectorOps.cpp
-	functionInterpreter.cpp
-	charMapper.cpp
-	workQueue.cpp
-	zipUtilities.cpp
-	base64.cpp
-	matrixCreation.cpp
-	logger.cpp
-	matrixDataSparse.cpp
-	OperatingBoundary.cpp
-	stringToCmdLine.cpp
-	TripWire.cpp
-	)
+set(
+    utilities_sources
+    gridRandom.cpp
+    saturation.cpp
+    stringOps.cpp
+    string_viewOps.cpp
+    ThreePhaseFunctions.cpp
+    matrixOps.cpp
+    stringConversion.cpp
+    units.cpp
+    vectorOps.cpp
+    functionInterpreter.cpp
+    charMapper.cpp
+    workQueue.cpp
+    zipUtilities.cpp
+    base64.cpp
+    matrixCreation.cpp
+    logger.cpp
+    matrixDataSparse.cpp
+    OperatingBoundary.cpp
+    stringToCmdLine.cpp
+    TripWire.cpp
+)
 
-set(utilities_headers
-	units.h
-	dataDictionary.hpp
-	timeSeries.hpp
-	charMapper.h
-	timeSeriesMulti.hpp
-	ThreePhaseFunctions.h
-	vectorOps.hpp
-	generic_string_ops.hpp
-	stringOps.h
-	string_viewOps.h
-	string_viewDef.h
-	optionalDef.hpp
-	gridRandom.h
-	saturation.h
-	vectData.hpp
-	matrixData.hpp
-	matrixOps.h
-	matrixDataCompact.hpp
-	matrixDataSparse.hpp
-	matrixDataSparse_impl.hpp
-	matrixDataBoost.hpp
-	matrixDataSparseSM.hpp
-	matrixDataTranslate.hpp
-	matrixDataContainer.hpp
-	matrixDataScale.hpp
-	matrixDataOrdered.hpp
-	matrixDataOrdering.hpp
-	matrixDataFilter.hpp
-	matrixDataCustomWriteOnly.hpp
-	functionInterpreter.h
-	TripWire.hpp
-	workQueue.h
-	simpleQueue.hpp
-	zipUtilities.h
-	base64.h
-	stringConversion.h
-	string_viewConversion.h
-	mapOps.hpp
-	valuePredictor.hpp
-	matrixCreation.h
-	timeRepresentation.hpp
-	indexTypes.hpp
-	logger.h
-	OperatingBoundary.h
-	stringToCmdLine.h
-	)
+set(
+    utilities_headers
+    units.h
+    dataDictionary.hpp
+    timeSeries.hpp
+    charMapper.h
+    timeSeriesMulti.hpp
+    ThreePhaseFunctions.h
+    vectorOps.hpp
+    generic_string_ops.hpp
+    stringOps.h
+    string_viewOps.h
+    string_viewDef.h
+    optionalDef.hpp
+    gridRandom.h
+    saturation.h
+    vectData.hpp
+    matrixData.hpp
+    matrixOps.h
+    matrixDataCompact.hpp
+    matrixDataSparse.hpp
+    matrixDataSparse_impl.hpp
+    matrixDataBoost.hpp
+    matrixDataSparseSM.hpp
+    matrixDataTranslate.hpp
+    matrixDataContainer.hpp
+    matrixDataScale.hpp
+    matrixDataOrdered.hpp
+    matrixDataOrdering.hpp
+    matrixDataFilter.hpp
+    matrixDataCustomWriteOnly.hpp
+    functionInterpreter.h
+    TripWire.hpp
+    workQueue.h
+    simpleQueue.hpp
+    zipUtilities.h
+    base64.h
+    stringConversion.h
+    string_viewConversion.h
+    mapOps.hpp
+    valuePredictor.hpp
+    matrixCreation.h
+    timeRepresentation.hpp
+    indexTypes.hpp
+    logger.h
+    OperatingBoundary.h
+    stringToCmdLine.h
+)
 
 add_library(utilities STATIC ${utilities_sources} ${utilities_headers})
 
@@ -91,8 +93,8 @@ include(buildMiniZip)
 # ------------------------------------------------------------
 set(ZLIB_ROOT_DIR ${AUTOBUILD_INSTALL_PATH})
 
-if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
-	build_zlib()
+if(NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
+    build_zlib()
 endif()
 include(${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
 
@@ -100,25 +102,30 @@ include(${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
 # building minizip
 # ------------------------------------------------------------
 set(ZLIB_INCLUDES ${AUTOBUILD_INSTALL_PATH}/include)
-if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/minizip-targets.cmake)
-	build_minizip()
+if(NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/minizip-targets.cmake)
+    build_minizip()
 endif()
 include(${AUTOBUILD_INSTALL_PATH}/cmake/minizip-targets.cmake)
 
-
 target_link_libraries(utilities PUBLIC minizip::minizip zlib::zlib griddyn_base)
-set_target_properties (utilities PROPERTIES FOLDER libraries)
+set_target_properties(utilities PROPERTIES FOLDER libraries)
 
-IF (ENABLE_64_BIT_INDEXING)
-target_compile_definitions(utilities PUBLIC -DENABLE_64_BIT_INDEXING)
-ENDIF(ENABLE_64_BIT_INDEXING)
-IF (UNSIGNED_INDEXING)
-target_compile_definitions(utilities PUBLIC -DUNSIGNED_INDEXING)
-ENDIF(UNSIGNED_INDEXING)
+if(ENABLE_64_BIT_INDEXING)
+    target_compile_definitions(utilities PUBLIC -DENABLE_64_BIT_INDEXING)
+endif(ENABLE_64_BIT_INDEXING)
+if(UNSIGNED_INDEXING)
+    target_compile_definitions(utilities PUBLIC -DUNSIGNED_INDEXING)
+endif(UNSIGNED_INDEXING)
 
-INSTALL(TARGETS utilities EXPORT griddyn-targets DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+install(
+    TARGETS utilities
+    EXPORT griddyn-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libraries
+)
 
-
-INSTALL(FILES ${utilities_headers}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/utilities
-  COMPONENT headers)
+install(
+    FILES ${utilities_headers}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/utilities
+    COMPONENT headers
+)

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -86,9 +86,9 @@ add_library(utilities STATIC ${utilities_sources} ${utilities_headers})
 include(buildZlib)
 
 include(buildMiniZip)
-###########################################
+# ------------------------------------------------------------
 # building zlib
-###########################################
+# ------------------------------------------------------------
 set(ZLIB_ROOT_DIR ${AUTOBUILD_INSTALL_PATH})
 
 if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
@@ -96,9 +96,9 @@ if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
 endif()
 include(${AUTOBUILD_INSTALL_PATH}/cmake/zlib-targets.cmake)
 
-###########################################
+# ------------------------------------------------------------
 # building minizip
-###########################################
+# ------------------------------------------------------------
 set(ZLIB_INCLUDES ${AUTOBUILD_INSTALL_PATH}/include)
 if (NOT EXISTS ${AUTOBUILD_INSTALL_PATH}/cmake/minizip-targets.cmake)
 	build_minizip()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,148 +8,185 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-set(testComponent_sources
+set(
+    testComponent_sources
     componentTests/ConditionTests.cpp
-	componentTests/testComponents.cpp
-	componentTests/testLoads.cpp
-	componentTests/testRecorders.cpp
-	componentTests/testExciters.cpp
-	componentTests/testGovernors.cpp
-	componentTests/testAdjustableTX.cpp
-	componentTests/testGenModels.cpp
-	componentTests/testdcLinks.cpp
-	componentTests/testLinks.cpp
-	componentTests/testRelays.cpp
-	componentTests/testBlocks.cpp
-	componentTests/testGenerators.cpp
-	componentTests/testArea.cpp
-	componentTests/testSource.cpp
-	componentTests/simulationTests.cpp
-	componentTests/testEvents.cpp
-	componentTests/testExtraModels.cpp
-	testHelperFunctions.cpp
-	exeTestHelper.cpp
-	)
+    componentTests/testComponents.cpp
+    componentTests/testLoads.cpp
+    componentTests/testRecorders.cpp
+    componentTests/testExciters.cpp
+    componentTests/testGovernors.cpp
+    componentTests/testAdjustableTX.cpp
+    componentTests/testGenModels.cpp
+    componentTests/testdcLinks.cpp
+    componentTests/testLinks.cpp
+    componentTests/testRelays.cpp
+    componentTests/testBlocks.cpp
+    componentTests/testGenerators.cpp
+    componentTests/testArea.cpp
+    componentTests/testSource.cpp
+    componentTests/simulationTests.cpp
+    componentTests/testEvents.cpp
+    componentTests/testExtraModels.cpp
+    testHelperFunctions.cpp
+    exeTestHelper.cpp
+)
 
-	if (NOT GRIDDYN_HAVE_MPI)
-	list(APPEND testComponent_sources componentTests/testGridLab.cpp)
-	endif()
+if(NOT GRIDDYN_HAVE_MPI)
+    list(APPEND testComponent_sources componentTests/testGridLab.cpp)
+endif()
 
-	list(APPEND testComponent_sources ${optional_component_test_files})
+list(APPEND testComponent_sources ${optional_component_test_files})
 
-set (testLibrary_sources
-	libraryTests/testCore.cpp
-	libraryTests/testXML.cpp
-	libraryTests/testStringOps.cpp
-	libraryTests/testString_viewOps.cpp
-	testHelperFunctions.cpp
-	exeTestHelper.cpp
-	libraryTests/libraryTests.cpp
-	libraryTests/testGridDynRunner.cpp
-	libraryTests/testElementReaders.cpp
-	libraryTests/testGridParameter.cpp
-	libraryTests/testJsonReader.cpp
-	libraryTests/testReaderInfo.cpp
-	libraryTests/testMatrixData.cpp
-	libraryTests/testWorkQueue.cpp
-	libraryTests/testZipUtilities.cpp
-	libraryTests/testStringConversion.cpp
-	libraryTests/testString_viewConversion.cpp
-	libraryTests/simpleQueueTests.cpp
-	libraryTests/testOperatingBounds.cpp
-	libraryTests/testValuePredictors.cpp
-	)
+set(
+    testLibrary_sources
+    libraryTests/testCore.cpp
+    libraryTests/testXML.cpp
+    libraryTests/testStringOps.cpp
+    libraryTests/testString_viewOps.cpp
+    testHelperFunctions.cpp
+    exeTestHelper.cpp
+    libraryTests/libraryTests.cpp
+    libraryTests/testGridDynRunner.cpp
+    libraryTests/testElementReaders.cpp
+    libraryTests/testGridParameter.cpp
+    libraryTests/testJsonReader.cpp
+    libraryTests/testReaderInfo.cpp
+    libraryTests/testMatrixData.cpp
+    libraryTests/testWorkQueue.cpp
+    libraryTests/testZipUtilities.cpp
+    libraryTests/testStringConversion.cpp
+    libraryTests/testString_viewConversion.cpp
+    libraryTests/simpleQueueTests.cpp
+    libraryTests/testOperatingBounds.cpp
+    libraryTests/testValuePredictors.cpp
+)
 
-	list(APPEND testLibrary_sources ${optional_library_test_files})
+list(APPEND testLibrary_sources ${optional_library_test_files})
 
-set(testSystem_sources
-	systemTests/testSystem.cpp
-	systemTests/testpFlow.cpp
-	systemTests/testDyn1.cpp
-	testHelperFunctions.cpp
-	exeTestHelper.cpp
-	systemTests/testDyn2.cpp
-	systemTests/testInputs.cpp
-	systemTests/testRoots.cpp
-	systemTests/testConstraints.cpp
-	systemTests/validationTests.cpp
-	systemTests/testSolverModes.cpp
-	systemTests/testMainExe.cpp
-	systemTests/testOutputs.cpp
-	systemTests/testCloning.cpp
-	systemTests/faultTests.cpp
-	systemTests/testContingency.cpp
-	systemTests/testGridDynRunner.cpp
-	)
+set(
+    testSystem_sources
+    systemTests/testSystem.cpp
+    systemTests/testpFlow.cpp
+    systemTests/testDyn1.cpp
+    testHelperFunctions.cpp
+    exeTestHelper.cpp
+    systemTests/testDyn2.cpp
+    systemTests/testInputs.cpp
+    systemTests/testRoots.cpp
+    systemTests/testConstraints.cpp
+    systemTests/validationTests.cpp
+    systemTests/testSolverModes.cpp
+    systemTests/testMainExe.cpp
+    systemTests/testOutputs.cpp
+    systemTests/testCloning.cpp
+    systemTests/faultTests.cpp
+    systemTests/testContingency.cpp
+    systemTests/testGridDynRunner.cpp
+)
 
-	list(APPEND testSystem_sources ${optional_system_test_files})
+list(APPEND testSystem_sources ${optional_system_test_files})
 
-set(testExtra_sources
-	extraTests/testExtra.cpp
-	extraTests/performanceTests.cpp
-	extraTests/largeContingencyTests.cpp
-	extraTests/largeInputTests.cpp
-	extraTests/objectSizeReport.cpp
-	testHelperFunctions.cpp
-	exeTestHelper.cpp
+set(
+    testExtra_sources
+    extraTests/testExtra.cpp
+    extraTests/performanceTests.cpp
+    extraTests/largeContingencyTests.cpp
+    extraTests/largeInputTests.cpp
+    extraTests/objectSizeReport.cpp
+    testHelperFunctions.cpp
+    exeTestHelper.cpp
 )
 
 if(FMI_ENABLE)
     list(APPEND testExtra_sources extraTests/extraFMUtests.cpp)
 endif()
 
-set(testMain_headers
-	testHelper.h
-	exeTestHelper.h
-	)
+set(testMain_headers testHelper.h exeTestHelper.h)
 
-#add a baseline library for underlying dependencies and flags for test executables
+# add a baseline library for underlying dependencies and flags for test executables
 add_library(griddyn_test_base INTERFACE)
 target_link_libraries(griddyn_test_base INTERFACE Boostlibs::test)
 target_link_libraries(griddyn_test_base INTERFACE griddyn_base)
 
-FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test_files test_dir)
+file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test_files test_dir)
 
-IF(WIN32)
-	#there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
-	#this will probably fail on macs yet
+if(WIN32)
+    # there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
+    # this will probably fail on macs yet
 
-	STRING(REGEX REPLACE "\\\\" "\\\\\\\\" test_dir ${test_dir})
-ENDIF(WIN32)
-#message(${test_dir})
+    string(
+        REGEX
+        REPLACE
+            "\\\\"
+            "\\\\\\\\"
+            test_dir
+            ${test_dir}
+    )
+endif(WIN32)
+# message(${test_dir})
 
-target_compile_definitions(griddyn_test_base INTERFACE -DGRIDDYN_TEST_DIRECTORY="${test_dir}" )
+target_compile_definitions(
+    griddyn_test_base INTERFACE -DGRIDDYN_TEST_DIRECTORY="${test_dir}"
+)
 
-target_compile_definitions(griddyn_test_base INTERFACE -DGRIDDYNMAIN_LOCATION="${GRIDYNMAIN_BINARY_LOC}")
-target_compile_definitions(griddyn_test_base INTERFACE -DGRIDDYNSERVER_LOCATION="${GRIDYNSERVER_BINARY_LOC}")
-target_compile_definitions(griddyn_test_base INTERFACE -DGRIDDYNINSTALL_LOCATION="${CMAKE_INSTALL_PREFIX}")
+target_compile_definitions(
+    griddyn_test_base INTERFACE
+    -DGRIDDYNMAIN_LOCATION="${GRIDYNMAIN_BINARY_LOC}"
+)
+target_compile_definitions(
+    griddyn_test_base INTERFACE
+    -DGRIDDYNSERVER_LOCATION="${GRIDYNSERVER_BINARY_LOC}"
+)
+target_compile_definitions(
+    griddyn_test_base INTERFACE
+    -DGRIDDYNINSTALL_LOCATION="${CMAKE_INSTALL_PREFIX}"
+)
 
 add_executable(testLibrary ${testLibrary_sources} ${testMain_headers})
 add_executable(testComponents ${testComponent_sources} ${testMain_headers})
 add_executable(testSystem ${testSystem_sources} ${testMain_headers})
 add_executable(testExtra ${testExtra_sources} ${testMain_headers})
 
-set_target_properties (testLibrary testComponents testSystem  testExtra PROPERTIES FOLDER tests)
-
-
+set_target_properties(
+    testLibrary
+    testComponents
+    testSystem
+    testExtra
+    PROPERTIES FOLDER tests
+)
 
 foreach(keyfile IN LISTS KEY_LIBRARY_FILES)
-add_custom_command(TARGET testComponents POST_BUILD        # Adds a post-build event to testComponents
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-        "${keyfile}"      # <--this is in-file
-        $<TARGET_FILE_DIR:testComponents>)                 # <--this is out-file path
+    add_custom_command(
+        TARGET
+        testComponents
+        POST_BUILD # Adds a post-build event to testComponents
+        COMMAND
+            ${CMAKE_COMMAND}
+            -E
+            copy_if_different # which executes "cmake - E copy_if_different..."
+            "${keyfile}" # <--this is in-file
+            $<TARGET_FILE_DIR:testComponents>
+    ) # <--this is out-file path
 endforeach(keyfile)
 
 target_link_libraries(testLibrary fileInput griddyn_test_base)
-target_link_libraries(testComponents ${executable_only_components} fileInput griddyn_test_base)
+target_link_libraries(
+    testComponents
+    ${executable_only_components}
+    fileInput
+    griddyn_test_base
+)
 target_link_libraries(testSystem fileInput griddyn_test_base)
 target_link_libraries(testExtra fileInput griddyn_test_base)
 
-
-#message(${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+# message(${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 install(DIRECTORY DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
-INSTALL(TARGETS testLibrary RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
-INSTALL(TARGETS testComponents RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
-INSTALL(TARGETS testSystem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
-INSTALL(TARGETS testExtra RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
-INSTALL(FILES ${KEY_LIBRARY_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
+install(TARGETS testLibrary RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
+install(
+    TARGETS testComponents
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/
+)
+install(TARGETS testSystem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
+install(TARGETS testExtra RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)
+install(FILES ${KEY_LIBRARY_FILES} DESTINATION ${CMAKE_INSTALL_BINDIR}/test/)

--- a/test/testSharedLibrary/CMakeLists.txt
+++ b/test/testSharedLibrary/CMakeLists.txt
@@ -1,69 +1,98 @@
 # LLNS Copyright Start
 # Copyright (c) 2014-2018, Lawrence Livermore National Security
-# This work was performed under the auspices of the U.S. Department 
-# of Energy by Lawrence Livermore National Laboratory in part under 
+# This work was performed under the auspices of the U.S. Department
+# of Energy by Lawrence Livermore National Laboratory in part under
 # Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
 # Produced at the Lawrence Livermore National Laboratory.
 # All rights reserved.
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
+set(shared_library_test_headers)
 
-set(shared_library_test_headers
+set(shared_library_test_sources shared_library_tests.cpp basic_tests.cpp)
 
+add_executable(
+    shared_library_tests ${shared_library_test_sources}
+    ${shared_library_test_headers}
 )
 
-set(shared_library_test_sources
-shared_library_tests.cpp
-basic_tests.cpp
+target_include_directories(
+    shared_library_tests SYSTEM
+    PUBLIC ${Boost_INCLUDE_DIR}
+)
+target_include_directories(
+    shared_library_tests
+    PUBLIC ${PROJECT_SOURCE_DIR}/src/griddyn_shared
 )
 
-add_executable(shared_library_tests ${shared_library_test_sources} ${shared_library_test_headers})
+set_target_properties(shared_library_tests PROPERTIES FOLDER tests)
 
-target_include_directories(shared_library_tests SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
-target_include_directories(shared_library_tests PUBLIC ${PROJECT_SOURCE_DIR}/src/griddyn_shared)
+file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/test/test_files test_dir)
 
-set_target_properties (shared_library_tests PROPERTIES FOLDER tests)
+if(WIN32)
+    # there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
+    # this will probably fail on macs yet
 
+    string(
+        REGEX
+        REPLACE
+            "\\\\"
+            "\\\\\\\\"
+            test_dir
+            ${test_dir}
+    )
+endif(WIN32)
+# message(${test_dir})
 
+target_compile_definitions(
+    shared_library_tests PRIVATE -DGRIDDYN_TEST_DIRECTORY="${test_dir}"
+)
 
-FILE(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/test/test_files test_dir)
+target_link_libraries(
+    shared_library_tests
+    PUBLIC griddyn_shared_lib ${Boost_LIBRARIES_test}
+)
 
-IF(WIN32)
-#there are 4 slashes because cmake escapes "\" and regex escapes it so I need 4
-#this will probably fail on macs yet
-
-STRING(REGEX REPLACE "\\\\" "\\\\\\\\" test_dir ${test_dir})
-ENDIF(WIN32)
-#message(${test_dir})
-
-target_compile_definitions(shared_library_tests PRIVATE -DGRIDDYN_TEST_DIRECTORY="${test_dir}" )
-
-target_link_libraries(shared_library_tests PUBLIC griddyn_shared_lib ${Boost_LIBRARIES_test})
-
-IF (VERSION_OPTION)
-	IF (MSVC)
-		target_compile_options(shared_library_tests PUBLIC ${VERSION_OPTION})
-	ELSE()
-		target_compile_options(shared_library_tests PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>)
-	ENDIF (MSVC)
-ENDIF(VERSION_OPTION)
+if(VERSION_OPTION)
+    if(MSVC)
+        target_compile_options(shared_library_tests PUBLIC ${VERSION_OPTION})
+    else()
+        target_compile_options(
+            shared_library_tests
+            PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>
+        )
+    endif(MSVC)
+endif(VERSION_OPTION)
 
 target_link_libraries(shared_library_tests PUBLIC ${Boost_LIBRARIES_core})
 
-
 add_test(NAME shared_library_tests COMMAND shared_library_tests)
 
-set_target_properties (testExtra PROPERTIES FOLDER tests)
+set_target_properties(testExtra PROPERTIES FOLDER tests)
 
 foreach(keyfile IN LISTS KEY_LIBRARY_FILES)
-add_custom_command(TARGET shared_library_tests POST_BUILD        # Adds a post-build event to api tests
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-        "${keyfile}"      # <--this is in-file
-        "$<TARGET_FILE_DIR:shared_library_tests>/")                 # <--this is out-file path
+    add_custom_command(
+        TARGET
+        shared_library_tests
+        POST_BUILD # Adds a post-build event to api tests
+        COMMAND
+            ${CMAKE_COMMAND}
+            -E
+            copy_if_different # which executes "cmake - E copy_if_different..."
+            "${keyfile}" # <--this is in-file
+            "$<TARGET_FILE_DIR:shared_library_tests>/"
+    ) # <--this is out-file path
 endforeach(keyfile)
 
-    add_custom_command(TARGET shared_library_tests POST_BUILD        # Adds a post-build event to api tests
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-            "$<TARGET_FILE:griddyn_shared_lib>"      # <--this is in-file
-            "$<TARGET_FILE_DIR:shared_library_tests>/")                 # <--this is out-file path
+add_custom_command(
+    TARGET
+    shared_library_tests
+    POST_BUILD # Adds a post-build event to api tests
+    COMMAND
+        ${CMAKE_COMMAND}
+        -E
+        copy_if_different # which executes "cmake - E copy_if_different..."
+        "$<TARGET_FILE:griddyn_shared_lib>" # <--this is in-file
+        "$<TARGET_FILE_DIR:shared_library_tests>/"
+) # <--this is out-file path


### PR DESCRIPTION
 * add cmake-format.json (only non-defaults are tab size, set to 4, and keyword_case, set to "upper")
 * manually change `######...` to `# ----------...`, as it deletes multiple `#`s
 * this only covers ./CMakeLists.txt and the ones in src and test
 * cmake-format converts indented comments to bulleted lists sometimes. I don't think any of that happened here, but it did when I ran on the config directory
   * (those changes aren't in here, I'm still looking through them)