### PR TITLE
Print ctest options

### DIFF
--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -101,7 +101,7 @@ else
 
     # Run the CI tests last so that the execution status is used for the pass/fail status shown
     if [[ "$DISABLE_UNIT_TESTS" != "true" ]]; then
-        echo "Running ${TEST_CONFIG} tests"
+        echo "Running ${TEST_CONFIG} tests with these options: ${CTEST_OPTIONS}"
         ctest -L ${TEST_CONFIG} ${CTEST_OPTIONS}
     fi
 fi


### PR DESCRIPTION
This should make debugging things like these: https://travis-ci.org/LLNL/GridDyn/builds/411849665 -- where it's just some parameter that got formatted incorrectly -- easier going forward.