### PR TITLE
Add command line argument for adding events

### DIFF
--- a/src/runner/gridDynRunner.cpp
+++ b/src/runner/gridDynRunner.cpp
@@ -338,7 +338,7 @@ int processCommandArguments (std::shared_ptr<gridDynSimulation> &gds, readerInfo
         {
             EventInfo gdEI;
             gdEI.loadString (eS, gds->getRoot ());
-            auto gdE = make_event (gdEI, gds->getRoot ());
+            std::shared_ptr<Event> gdE = make_event (gdEI, gds->getRoot ());
             gds->add (std::move (gdE));
         }
     }

--- a/src/runner/gridDynRunner.cpp
+++ b/src/runner/gridDynRunner.cpp
@@ -21,6 +21,7 @@
 #include "coupling/GhostSwingBusManager.h"
 #include "fileInput/fileInput.h"
 #include "griddyn/measurement/Recorder.h"
+#include "griddyn/events/Event.h"
 #include "griddyn/simulation/gridDynSimulationFileOps.h"
 #include "utilities/stringOps.h"
 #include "utilities/workQueue.h"
@@ -330,6 +331,18 @@ int processCommandArguments (std::shared_ptr<gridDynSimulation> &gds, readerInfo
         return gds->getErrorCode ();
     }
 
+    if (vm.count ("event") > 0)
+    {
+        auto eventList = vm["event"].as<stringVec> ();
+        for (auto &eS : eventList)
+        {
+            EventInfo gdEI;
+            gdEI.loadString (eS, gds->getRoot ());
+            auto gdE = make_event (gdEI, gds->getRoot ());
+            gds->add (std::move (gdE));
+        }
+    }
+
     int areas = gds->getInt ("totalareacount");
     int buses = gds->getInt ("totalbuscount");
     int links = gds->getInt ("totallinkcount");
@@ -446,6 +459,7 @@ int argumentParser (int argc, char *argv[], po::variables_map &vm_map, bool allo
 		("param,P", po::value<std::vector<std::string>> (),"override simulation file parameters --param ParamName=<val>")
 		("dir",po::value<std::vector<std::string>> (),"add search directory for input files")
 		("import,i", po::value<std::vector<std::string>> (), "add import files loaded after the main input file")
+		("event", po::value<std::vector<std::string>> (), "add event after all input files")
 		("powerflow_only", "set the solver to stop after the power flow solution and use some powerflow specific models")
 		("powerflow-only", "set the solver to stop after the power flow solution and use some powerflow specific models")
 		("state-output", po::value<std::string> (),"file for final output state")


### PR DESCRIPTION
`--event` command line argument(s) that take an event string and add events (after the main input file and any additional import files are loaded). The value and time for an event defined in the files don't seem to support substitution using defines, and this is easier than modifying existing files -- adding an import to the main input config file produces slightly different values than including the imported file using `--import` (at time steps before an event is scheduled to occur), and including a file using import after the closing </griddyn> tag produces different output than including the import between the open/close tags.