### PR TITLE
Braid updates

### DIFF
--- a/bin/configure.griddyn_braid
+++ b/bin/configure.griddyn_braid
@@ -9,33 +9,22 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-#######
-#CC=mpicc CXX=mpic++ cmake .. \
-#     -DSUNDIALS_DIR=$SUNDIALS_DIR \
-#     -DSuiteSparse_DIR=$SuiteSparse_DIR \
-#     -DBOOST_ROOT=$BOOST_DIR \
+# Check if environment variable with path to XBraid install is set
+# e.g., export XBRAID_ROOT=~/apps/xbraid/barid
+if [ -z "$XBRAID_ROOT" ]; then
+    echo "ERROR: XBRAID_ROOT not set!"
+    exit 1
+fi
 
-#export SUNDIALS_DIR=~/powergrid/sundials-2.7.0-nopenmp/build/install
-#-DSUNDIALS_DIR=$SUNDIALS_DIR \
-######
-
-export INSTALL_DIR=./install
-
-# Can choose between
-#    -DCMAKE_BUILD_TYPE=debug \
-# Or,
-#    -DCMAKE_BUILD_TYPE=release \
-
-CC=gcc CXX=g++ cmake .. \
-    -DMPI_ENABLE=ON \
-    -DOPENMP_ENABLE=OFF \
-    -DSUNDIALS_OPENMP=OFF \
-    -DCMAKE_BUILD_TYPE=release \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DOPTIMIZATION_ENABLE=ON \
-    -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-    -DLOAD_EXTRA_SOLVERS=ON \
-    -DBUILD_BRAID_SOLVER=ON \
-    -DBRAID_INSTALL_DIR=/g/g18/schroder/powergrid/powergrid_sandbox/braid/braid \
-    -DUSE_POSITION_INDEPENDENT_CODE=ON \
-#    -DDISABLE_MULTITHREADING=ON \
+# Configure GridDyn
+cmake .. \
+      -D CMAKE_BUILD_TYPE=release \
+      -D CMAKE_INSTALL_PREFIX=./install \
+      -D BUILD_SHARED_LIBS=OFF \
+      -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -D GRIDDYN_ENABLE_MPI=ON \
+      -D GRIDDYN_ENABLE_OPENMP=OFF \
+      -D GRIDDYN_ENABLE_OPTIMIZATION_LIBRARY=ON \
+      -D GRIDDYN_ENABLE_EXTRA_SOLVERS=ON \
+      -D BUILD_BRAID_SOLVER=ON \
+      -D BRAID_INSTALL_DIR="$XBRAID_ROOT"

--- a/config/cmake/FindKLU.cmake
+++ b/config/cmake/FindKLU.cmake
@@ -60,7 +60,7 @@ if (KLU_DIR)
 
 
     # The set of required KLU libraries
-    set(KLU_REQUIRED_LIBS klu amd colamd btf)
+    set(KLU_REQUIRED_LIBS klu amd colamd btf umfpack)
     set(KLU_REQUIRED_IFFOUND_LIBS cxsparse suitesparseconfig)
 
     foreach(TEST_LIB IN LISTS KLU_REQUIRED_LIBS)

--- a/config/cmake/addKLU.cmake
+++ b/config/cmake/addKLU.cmake
@@ -42,7 +42,7 @@ set(SuiteSparseNameSpace Suitesparse)
 cmake_dependent_advanced_option(${PROJECT_NAME}_USE_SUITESPARSE_STATIC_LIBRARY "use the suitesparse static library" OFF  "NOT ${PROJECT_NAME}_USE_SYSTEM_SUITESPARSE_ONLY"
         OFF)
 
-set (SUITESPARSE_COMPONENTS klu btf amd colamd suitesparseconfig)
+set (SUITESPARSE_COMPONENTS klu btf amd colamd umfpack suitesparseconfig)
 if(${PROJECT_NAME}_USE_SYSTEM_SUITESPARSE_ONLY)
     find_package(SuiteSparse COMPONENTS ${SUITESPARSE_COMPONENTS})
     set(${PROJECT_NAME}_SUITESPARSE_LOCAL_BUILD OFF CACHE INTERNAL "")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ GridDyn uses C++11 extensively and will make use of some C++14 features in the n
 - **LOAD_CVODE** build in support for CVODE for solving differential equations Neither cvode or arkode are used at present but will be in the near future
 - **ENABLE_EXTRA_MODELS** select to build an additional library containing a few optional models-more will likely be added in the future
 - **ENABLE_GRIDDYN_LOGGING** unselect to turn off all logging functions
-- **ENABLE_MPI** select to build with MPI support using an MPI compatible compiler
+- **GRIDDYN_ENABLE_MPI** select to build with MPI support using an MPI compatible compiler
 - **ENABLE_OPENMP** option to build in support for openMP in both the solvers and in GridDyn
 - **ENABLE_OPTIMIZATION_LIBRARY** enable building of the optimization extension. This is a work in progress and doesn't do much yet, recommended to leave unselected unless you are developing on that section.
 - **SUNDIALS_INSTALLATION_DIR** point to the installation location for SUNDIALS

--- a/examples/braid_examples/README.md
+++ b/examples/braid_examples/README.md
@@ -1,0 +1,45 @@
+# GridDyn + XBraid Examples
+
+## 179busDynamicTest_BraidWithEvents
+
+This test has an event applied to the system at every half-second, that is at
+t = 0.5, 1.5, 2.5, ..., 9.5. This event is a load applied at a specific bus with
+a magnitude of 0.1 megawatts. The load and affected bus can be changed by editing
+the file `179busDynamicTest_BraidWithEvents.xml`.
+
+## 179busDynamicTest_BraidNoEvents
+
+The is the same as the 179busDynamicTest_BraidWithEvents examples but with no
+events.
+
+## XBraid options
+
+In a GridDyn XML input file, parallel-in-time integration with XBraid is enabled
+with the option
+```
+<solver name="braid">  </solver>
+<defdae>braid</defdae>
+```
+All the relevant XBraid parameters are set in the XBraid parameter file. The
+default name for this file is `braid_params.ini`. An alternative input file
+name can be specified in the GridDyn XML input file with
+```
+<solver name="braid">
+   <configfile>braid_params.ini</configfile>
+</solver>
+<defdae>braid</defdae>
+```
+The set of event locations can be set with
+```
+<solver name="braid">
+   <configfile>braid_params.ini</configfile>
+   <discontinuities>0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5</discontinuities>
+</solver>
+<defdae>braid</defdae>
+```
+The time domain size and the time-step size are controlled with
+```
+<timestart>0</timestart>
+<timestop>10</timestop>
+<timestep>0.048</timestep>
+```

--- a/src/coupling/CMakeLists.txt
+++ b/src/coupling/CMakeLists.txt
@@ -12,10 +12,10 @@
 set(coupling_sources GhostSwingBusManager.cpp)
 
 set(coupling_headers GhostSwingBusManager.h GhostSwingBusMessageTypes.h)
-if(ENABLE_MPI)
+if(GRIDDYN_ENABLE_MPI)
     list(APPEND coupling_sources MpiService.cpp)
     list(APPEND coupling_headers MpiService.h)
-endif(ENABLE_MPI)
+endif(GRIDDYN_ENABLE_MPI)
 # require MPI for this project
 
 add_library(coupling_static_lib STATIC ${coupling_sources} ${coupling_headers})

--- a/src/coupling/GhostSwingBusManager.cpp
+++ b/src/coupling/GhostSwingBusManager.cpp
@@ -11,7 +11,7 @@
  */
 
 #include "GhostSwingBusManager.h"
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
 #    include "MpiService.h"
 #    include <mpi.h>
 #endif
@@ -32,7 +32,7 @@ std::shared_ptr<GhostSwingBusManager> GhostSwingBusManager::m_pInstance = nullpt
 std::shared_ptr<GhostSwingBusManager> GhostSwingBusManager::Instance()
 {
     if (!m_pInstance) {
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
         throw(std::runtime_error("GhostSwingBusManager Instance does not exist!"));
 #else  // mainly for convenience on a windows system for testing purposes the GhostSwingBus doesn't do anything \
     // without MPI
@@ -59,7 +59,7 @@ bool GhostSwingBusManager::isInstance()
 
 GhostSwingBusManager::GhostSwingBusManager(int* argc, char** argv[])
 {
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     servicer = mpi::MpiService::instance(argc, argv);
 
     m_numTasks = servicer->getCommSize();
@@ -93,7 +93,7 @@ int GhostSwingBusManager::createGridlabDInstance(const string& arguments)
              << endl;
     }
 
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     auto* arguments_c = const_cast<char*>(arguments.c_str());
     m_initializeCompleted[taskId] = false;
     auto token = servicer->getToken();
@@ -148,7 +148,7 @@ void GhostSwingBusManager::sendVoltageStep(int taskId, cvec& voltage, unsigned i
     m_voltSendMessage[taskId].numThreePhaseVoltage = numThreePhaseVoltage;
     m_voltSendMessage[taskId].deltaTime = deltaTime;
 
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     auto token = servicer->getToken();
     if (!m_initializeCompleted[taskId]) {
         MPI_Status status;
@@ -193,7 +193,7 @@ void GhostSwingBusManager::sendStopMessage(int taskId)
     if (g_printStuff) {
         cout << "Sending STOP message to Distribution task " << taskId << endl;
     }
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     // Blocking send to gridlabd task
     auto token = servicer->getToken();
     MPI_Send(&m_voltSendMessage[taskId], 1, MPI_BYTE, taskId, STOPTAG, MPI_COMM_WORLD);
@@ -208,7 +208,7 @@ void GhostSwingBusManager::getCurrent(int taskId, cvec& current)
         cout << "Transmission *waiting* to get current from Task: " << taskId << endl;
     }
 
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     {
         MPI_Status status;
         auto token = servicer->getToken();
@@ -248,7 +248,7 @@ void GhostSwingBusManager::endSimulation()
         sendStopMessage(i);
     }
 
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
 
     if (g_printStuff) {
         cout << "end task : " << m_taskId << endl;

--- a/src/coupling/GhostSwingBusManager.h
+++ b/src/coupling/GhostSwingBusManager.h
@@ -15,7 +15,7 @@
 #include "GhostSwingBusMessageTypes.h"
 #include "griddyn/griddyn-config.h"
 
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
 #    include <functional>
 #endif
 
@@ -104,7 +104,7 @@ class GhostSwingBusManager {
 
     static void SetDebug(bool debug) { g_printStuff = debug; }
 
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
     /**
      * sets the dummy load function
      */
@@ -117,7 +117,7 @@ class GhostSwingBusManager {
 
   private:
     static bool g_printStuff;  //!< public boolean to change whether things are printed or not
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     mpi::MpiService* servicer;  //!< pointer to the global MpiService
 #endif
     /**
@@ -146,7 +146,7 @@ class GhostSwingBusManager {
     static std::shared_ptr<GhostSwingBusManager> m_pInstance;
 
     int m_numTasks = 20;
-#ifdef ENABLE_MPI
+#ifdef GRIDDYN_ENABLE_MPI
     int m_taskId = 0;
     /*
      * Async send requests

--- a/src/extraSolvers/CMakeLists.txt
+++ b/src/extraSolvers/CMakeLists.txt
@@ -196,9 +196,9 @@ target_include_directories(extraSolverLibrary PRIVATE ${SuiteSparse_DIRECT_INCLU
 #     COMPONENT libraries
 # )
 
-# install(FILES ${extra_solver_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
-#         COMPONENT headers
-# )
+install(FILES ${extra_solver_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
+        COMPONENT headers
+)
 
 list(APPEND optional_library_key_headers extraSolvers/extraSolvers.h)
 list(APPEND optional_library_functions loadExtraSolvers)

--- a/src/extraSolvers/CMakeLists.txt
+++ b/src/extraSolvers/CMakeLists.txt
@@ -140,7 +140,7 @@ elseif(BUILD_PARADAE_SOLVERS)
     list(APPEND extra_solver_headers ${paradae_headers})
 endif()
 
-if(ENABLE_MPI)
+if(GRIDDYN_ENABLE_MPI)
     list(APPEND extra_solver_sources paradae/common/MapParam.cxx paradae/common/Timer.cxx)
     list(APPEND extra_solver_headers paradae/common/def_mpi.h paradae/common/MapParam.h
          paradae/common/Timer.h
@@ -149,7 +149,7 @@ elseif(BUILD_BRAID_SOLVER)
     message(WARNING "Braid requires MPI to function")
 endif()
 
-find_library(UMFPACK_LIBRARY umfpack HINTS ${SuiteSparse_DIRECT_LIBRARY_DIR})
+# find_library(UMFPACK_LIBRARY umfpack HINTS ${SuiteSparse_DIRECT_LIBRARY_DIR})
 
 # find_package(LAPACKE) if (LAPACKE_FOUND) INCLUDE_DIRECTORIES(${LAPACKE_INCLUDE_DIRS}) endif()
 
@@ -166,7 +166,7 @@ endif(WIN32)
 
 target_link_libraries(extraSolverLibrary PUBLIC griddyn)
 target_link_libraries(extraSolverLibrary PUBLIC ${LAPACKE_LIBRARIES})
-target_link_libraries(extraSolverLibrary PUBLIC SuiteSparse::umfpack)
+target_link_libraries(extraSolverLibrary PUBLIC ${SuiteSparse_UMFPACK_LIBRARY_RELEASE})
 
 if(BUILD_PARADAE_SOLVERS OR BUILD_BRAID_SOLVER)
     # source_group("paradae" FILES ${paradae_sources} ${paradae_headers})
@@ -183,22 +183,22 @@ if(BUILD_BRAID_SOLVER)
     target_compile_definitions(extraSolverLibrary PUBLIC "-DENABLE_BRAID")
 endif()
 
-if(ENABLE_MPI)
+if(GRIDDYN_ENABLE_MPI)
     target_link_libraries(extraSolverLibrary PUBLIC MPI::MPI_C)
-endif(ENABLE_MPI)
+endif(GRIDDYN_ENABLE_MPI)
 
 target_include_directories(extraSolverLibrary PRIVATE ${SuiteSparse_DIRECT_INCLUDE_DIR})
 
-install(
-    TARGETS extraSolverLibrary
-    EXPORT griddyn-targets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libraries
-)
+# install(
+#     TARGETS extraSolverLibrary
+#     EXPORT griddyn-targets
+#     DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#     COMPONENT libraries
+# )
 
-install(FILES ${extra_solver_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
-        COMPONENT headers
-)
+# install(FILES ${extra_solver_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/griddyn/extraSolver
+#         COMPONENT headers
+# )
 
 list(APPEND optional_library_key_headers extraSolvers/extraSolvers.h)
 list(APPEND optional_library_functions loadExtraSolvers)

--- a/src/extraSolvers/braid/braidSolver.cpp
+++ b/src/extraSolvers/braid/braidSolver.cpp
@@ -24,8 +24,8 @@
 #include "griddyn/gridDynSimulation.h"
 #include "griddyn/solvers/solverInterface.h"
 #include "mpi.h"
-#include "utilities/string_viewConversion.h"
-#include "utilities/vectorOps.hpp"
+#include "gmlc/utilities/string_viewConversion.h"
+#include "gmlc/utilities/vectorOps.hpp"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -191,7 +191,7 @@ namespace braid {
         if ((param == "configfile") || (param == "file") || (param == "config_file")) {
             configFile = val;
         } else if (param == "discontinuities") {
-            discontinuities = str2vector<double>(val, 0.0);
+            discontinuities = gmlc::utilities::str2vector<double>(val, 0.0);
             std::sort(discontinuities.begin(), discontinuities.end(), std::less<>());
         } else {
             SolverInterface::set(param, val);

--- a/src/griddyn/loads/gridLabDLoad.cpp
+++ b/src/griddyn/loads/gridLabDLoad.cpp
@@ -56,7 +56,7 @@ namespace loads {
                 }
 
                 opFlags.set(file_sent_flag);
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
                 for (size_t kk = 0; kk < gridlabDfile.size(); ++kk) {
                     if (!(dummy_load[kk])) {
                         dummy_load[kk] = std::make_unique<zipLoad>(0.3, 0.1, "dummy");
@@ -197,7 +197,7 @@ namespace loads {
     {
         double V = inputs[voltageInLocation];
         double th = inputs[angleInLocation];
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
         // if we have a dummy load progress it in time appropriately
         for (auto& dl : dummy_load) {
             if (dl) {
@@ -237,7 +237,7 @@ namespace loads {
         IOdata inputs(2);
         inputs[voltageInLocation] = V;
         inputs[angleInLocation] = th;
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
         // if we have a dummy load progress it in time appropriately
         for (auto& dl : dummy_load) {
             if (dl) {
@@ -866,7 +866,7 @@ namespace loads {
                 if (num > static_cast<int>(gridlabDfile.size())) {
                     gridlabDfile.resize(num);
                     workdir.resize(num);
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
                     dummy_load.resize(num);
                     dummy_load_forward.resize(num);
 #endif
@@ -875,7 +875,7 @@ namespace loads {
             } else {
                 gridlabDfile.push_back(val);
                 workdir.resize(gridlabDfile.size());
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
                 dummy_load.resize(gridlabDfile.size());
                 dummy_load_forward.resize(gridlabDfile.size());
 #endif
@@ -887,7 +887,7 @@ namespace loads {
                 if (num > static_cast<int>(gridlabDfile.size())) {
                     gridlabDfile.resize(num);
                     workdir.resize(num);
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
                     dummy_load.resize(num);
                     dummy_load_forward.resize(num);
 #endif
@@ -1031,7 +1031,7 @@ namespace loads {
         return cnt;
     }
 
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
     void gridLabDLoad::run_dummy_load(index_t kk, VoltageMessage* vm, CurrentMessage* cm)
     {
         for (int ii = 0; ii < vm->numThreePhaseVoltage; ii++) {
@@ -1087,7 +1087,7 @@ namespace loads {
         }
         cm->numThreePhaseCurrent = vm->numThreePhaseVoltage;
     }
-#endif  // ENABLE_MPI
+#endif  // GRIDDYN_ENABLE_MPI
 
 }  // namespace loads
 }  // namespace griddyn

--- a/test/componentTests/testLoads.cpp
+++ b/test/componentTests/testLoads.cpp
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(file_load_test2)
     auto tod = Tdata.data()[0];
     BOOST_CHECK_CLOSE(val, tod, 0.0001);
 }
-#ifndef ENABLE_MPI
+#ifndef GRIDDYN_ENABLE_MPI
 BOOST_AUTO_TEST_CASE(gridDynLoad_test1)
 {
     std::string fileName = gridlabd_test_directory + "IEEE_13_mod.xml";


### PR DESCRIPTION
Updates to get the XBraid interface running on the develop branch. 

These changes includes some CMake workarounds in `src/extraSolvers/CMakeLists.txt` for running on quartz. Specifically, using `target_link_libraries(extraSolverLibrary PUBLIC ${SuiteSparse_UMFPACK_LIBRARY_RELEASE})` rather than`target_link_libraries(extraSolverLibrary PUBLIC SuiteSparse::umfpack)` and commenting out `install(TARGETS extraSolverLibrary...`.
